### PR TITLE
Fix infinite loop when persisting large batches

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,7 +16,9 @@ akka {
 
 eventuate {
   log.write {
-    # Maximum write batch size for emitted events by event-sourced actors.
+    # Maximum write batch size for emitted events by event-sourced actors. It
+    # is exceeded if the number of events in a single write request is higher
+    # than batch-size-max.
     batch-size-max = 200
   }
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/BatchingEventLog.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/BatchingEventLog.scala
@@ -79,7 +79,7 @@ class BatchingEventLog(eventLogProps: Props) extends Actor {
     var num = 0
     val (w, r) = batch.span { w =>
       num += w.events.size
-      num <= batchSizeLimit
+      num <= batchSizeLimit || num == w.events.size
     }
     eventLog ! WriteN(w)
     batch = r


### PR DESCRIPTION
writeAll() got stuck in an infinite loop if the number of events in a
single write was larger than the maximum batch size.