### PR TITLE
Cassandra storage backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,12 +23,17 @@ parallelExecution in Test := false
 
 fork in Test := true
 
+resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven"
+
 libraryDependencies ++= Seq(
+  "com.datastax.cassandra"           % "cassandra-driver-core"         % "2.1.5",
+  "com.google.guava"                 % "guava"                         % "16.0",
   "com.google.protobuf"              % "protobuf-java"                 % "2.5.0",
   "com.typesafe.akka"               %% "akka-remote"                   % akkaVersion,
   "com.typesafe.akka"               %% "akka-testkit"                  % akkaVersion  % "test,it",
   "com.typesafe.akka"               %% "akka-multi-node-testkit"       % akkaVersion  % "test",
   "commons-io"                       % "commons-io"                    % "2.4",
+  "org.cassandraunit"                % "cassandra-unit"                % "2.0.2.2"    % "test,it" excludeAll(ExclusionRule(organization = "ch.qos.logback")),
   "org.functionaljava"               % "functionaljava"                % "4.2-beta-1" % "test",
   "org.functionaljava"               % "functionaljava-java8"          % "4.2-beta-1" % "test,it",
   "org.fusesource.leveldbjni"        % "leveldbjni-all"                % "1.7",
@@ -39,8 +44,6 @@ libraryDependencies ++= Seq(
 // ----------------------------------------------------------------------
 //  Documentation
 // ----------------------------------------------------------------------
-
-import com.typesafe.sbt.site.SphinxSupport.Sphinx
 
 site.settings
 

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -1,3 +1,6 @@
 akka.loglevel = "ERROR"
+akka.test.single-expect-default = 10s
 
 eventuate.log.leveldb.dir = target/test
+eventuate.log.cassandra.default-port = 9142
+eventuate.log.cassandra.index-update-limit = 100

--- a/src/it/resources/log4j.properties
+++ b/src/it/resources/log4j.properties
@@ -1,0 +1,3 @@
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.SimpleLayout

--- a/src/it/scala/com/rbmhtechnology/eventuate/EventsourcedActorThroughputSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/EventsourcedActorThroughputSpec.scala
@@ -22,8 +22,8 @@ import scala.util._
 import akka.actor._
 import akka.testkit._
 
-import com.rbmhtechnology.eventuate.log.EventLogSupport
-import com.typesafe.config.ConfigFactory
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLogSupport
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLogSupport
 
 import org.scalatest._
 
@@ -88,9 +88,10 @@ object EventsourcedActorThroughputSpec {
   }
 }
 
-class EventsourcedActorThroughputSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with EventLogSupport {
+abstract class EventsourcedActorThroughputSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterEach {
   import EventsourcedActorThroughputSpec._
 
+  def log: ActorRef
   var probe: TestProbe = _
 
   override def beforeEach(): Unit = {
@@ -152,3 +153,6 @@ class EventsourcedActorThroughputSpec extends TestKit(ActorSystem("test")) with 
     }
   }
 }
+
+class EventsourcedActorThroughputSpecLeveldb extends EventsourcedActorThroughputSpec with LeveldbEventLogSupport
+class EventsourcedActorThroughputSpecCassandra extends EventsourcedActorThroughputSpec with CassandraEventLogSupport

--- a/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
@@ -19,7 +19,7 @@ package com.rbmhtechnology.eventuate
 import com.typesafe.config._
 
 object ReplicationConfig {
-  def create(node: String = "A", port: Int = 2552, customConfig: String = ""): Config = {
+  def create(port: Int = 2552, customConfig: String = ""): Config = {
     val defaultConfig = ConfigFactory.parseString(
       s"""
          |akka.actor.provider = "akka.remote.RemoteActorRefProvider"
@@ -30,7 +30,9 @@ object ReplicationConfig {
          |akka.test.single-expect-default = 10s
          |akka.loglevel = "ERROR"
          |
-         |eventuate.log.leveldb.dir = target/logs-system-${node}
+         |eventuate.log.leveldb.dir = target/test
+         |eventuate.log.cassandra.default-port = 9142
+         |eventuate.log.cassandra.index-update-limit = 3
          |eventuate.log.replication.batch-size-max = 3
          |eventuate.log.replication.retry-interval = 1s
          |eventuate.log.replication.failure-detection-limit = 3s

--- a/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpec.scala
@@ -3,15 +3,14 @@ package com.rbmhtechnology.eventuate.crdt
 import akka.actor._
 import akka.testkit._
 
-import com.rbmhtechnology.eventuate.log.EventLogSupport
-import com.typesafe.config.ConfigFactory
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLogSupport
 
 import org.scalatest._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
-class CRDTServiceSpec  extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with EventLogSupport {
+class CRDTServiceSpec  extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with LeveldbEventLogSupport {
   implicit class AwaitHelper[T](w: Awaitable[T]) {
     def await: T = Await.result(w, 3.seconds)
   }

--- a/src/it/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSupport.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSupport.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import akka.actor._
+import akka.pattern.ask
+import akka.testkit.{TestProbe, TestKit}
+import akka.util.Timeout
+
+import com.rbmhtechnology.eventuate._
+import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraIndex.IndexIncrement
+import com.rbmhtechnology.eventuate.log.{EventLogSpec, BatchingEventLog}
+import com.rbmhtechnology.eventuate.log.EventLogSpec._
+
+import org.scalatest._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util._
+
+object CassandraEventLogSupport {
+  case class TestFailureSpec(
+    failOnSequenceNrRead: Boolean = false,
+    failBeforeIndexIncrementWrite: Boolean = false,
+    failAfterIndexIncrementWrite: Boolean = false)
+
+  class TestEventLog(id: String, failureSpec: TestFailureSpec, indexProbe: ActorRef) extends CassandraEventLog(id) {
+    import context.dispatcher
+
+    private var index: ActorRef = _
+
+    override def write(batch: DurableEventBatch): Unit = batch.events match {
+      case es if es.map(_.payload).contains("boom") => throw boom
+      case _ => super.write(batch)
+    }
+
+    override def unhandled(message: Any): Unit = message match {
+      case GetSequenceNr =>
+        sender() ! GetSequenceNrSuccess(currentSequenceNr)
+      case GetReplicationProgress =>
+        val sdr = sender()
+        getReplicationProgress(List(EventLogSpec.remoteLogId, "x", "y")) onComplete {
+          case Success(r) => sdr ! GetReplicationProgressSuccess(r)
+          case Failure(e) => sdr ! GetReplicationProgressFailure(e)
+        }
+      case "boom" =>
+        throw boom
+      case _ =>
+        super.unhandled(message)
+    }
+
+    override private[eventuate] def createReader(cassandra: Cassandra, logId: String) =
+      new TestEventReader(cassandra, logId)
+
+    override private[eventuate] def createIndex(cassandra: Cassandra, eventReader: CassandraEventReader, logId: String): ActorRef = {
+      index = context.actorOf(Props(new TestIndex(cassandra, eventReader, logId, failureSpec, indexProbe)))
+      index
+    }
+
+    private def getReplicationProgress(sourceLogIds: Seq[String]): Future[Map[String, Long]] = {
+      implicit val timeout = Timeout(10.seconds)
+
+      Future.sequence(sourceLogIds.map(sourceLogId => index.ask(GetLastSourceLogReadPosition(sourceLogId)).mapTo[GetLastSourceLogReadPositionSuccess])).map { results =>
+        results.foldLeft[Map[String, Long]](Map.empty) {
+          case (acc, GetLastSourceLogReadPositionSuccess(logId, snr)) => if (snr == 0L) acc else acc + (logId -> snr)
+        }
+      }
+    }
+  }
+
+  class TestEventReader(cassandra: Cassandra, logId: String) extends CassandraEventReader(cassandra, logId) {
+    override def replay(from: Long)(f: (DurableEvent) => Unit): Unit =
+      if (from == -1L) throw boom else super.replay(from)(f)
+
+    override def read(from: Long, max: Int, filter: ReplicationFilter, targetLogId: String): CassandraEventReader.ReadResult =
+      if (from == -1L) throw boom else super.read(from, max, filter, targetLogId)
+  }
+
+  class TestIndex(cassandra: Cassandra, eventReader: CassandraEventReader, logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef) extends CassandraIndex(cassandra, eventReader, logId) {
+    val stream = context.system.eventStream
+
+    override private[eventuate] def createIndexStore(cassandra: Cassandra, logId: String) =
+      new TestIndexStore(cassandra, logId, failureSpec)
+
+    override def onIndexEvent(event: Any): Unit =
+      indexProbe ! event
+  }
+
+  class TestIndexStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraIndexStore(cassandra, logId) {
+    private var writeIndexIncrementFailed = false
+    private var readSequenceNumberFailed = false
+
+    override def writeIndexIncrementAsync(increment: IndexIncrement)(implicit executor: ExecutionContext): Future[Long] =
+      if (failureSpec.failBeforeIndexIncrementWrite && !writeIndexIncrementFailed) {
+        writeIndexIncrementFailed = true
+        Future.failed(boom)
+      } else if (failureSpec.failAfterIndexIncrementWrite && !writeIndexIncrementFailed) {
+        writeIndexIncrementFailed = true
+        for {
+          _ <- super.writeIndexIncrementAsync(increment)
+          r <- Future.failed(boom)
+        } yield r
+      } else super.writeIndexIncrementAsync(increment)
+
+    override def readSequenceNumberAsync: Future[Long] =
+      if (failureSpec.failOnSequenceNrRead && !readSequenceNumberFailed) {
+        readSequenceNumberFailed = true
+        Future.failed(boom)
+      } else super.readSequenceNumberAsync
+  }
+}
+
+trait CassandraEventLogSupport extends Suite with BeforeAndAfterAll with BeforeAndAfterEach {
+  import CassandraEventLogSupport._
+
+  private var _logCtr: Int = 0
+  private var _log: ActorRef = _
+
+  var indexProbe: TestProbe = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    indexProbe = TestProbe()
+
+    _logCtr += 1
+    _log = createLog(TestFailureSpec(), indexProbe.ref)
+  }
+
+  override def beforeAll(): Unit = {
+    CassandraServer.start(60.seconds)
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    CassandraServer.stop()
+  }
+
+  def createLog(failureSpec: TestFailureSpec, indexProbe: ActorRef): ActorRef =
+    system.actorOf(logProps(logId, failureSpec, indexProbe))
+
+  def log: ActorRef =
+    _log
+
+  def logId: String =
+    _logCtr.toString
+
+  def logProps(logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef): Props = {
+    val logProps = Props(new TestEventLog(logId, failureSpec, indexProbe)).withDispatcher("eventuate.log.cassandra.write-dispatcher")
+    if (batching) Props(new BatchingEventLog(logProps)) else logProps
+  }
+
+  def batching: Boolean =
+    true
+
+  implicit def system: ActorSystem
+}

--- a/src/it/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraServer.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraServer.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+
+import scala.concurrent.duration._
+
+object CassandraServer {
+  def start(timeout: FiniteDuration = 10.seconds): Unit =
+    EmbeddedCassandraServerHelper.startEmbeddedCassandra(timeout.toMillis)
+
+  def stop(): Unit =
+    EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+}
+
+object CassandraServerApp extends App {
+  CassandraServer.start(60.seconds)
+}

--- a/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationFilterSerializerSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationFilterSerializerSpec.scala
@@ -81,8 +81,8 @@ class ReplicationFilterSerializerSpec extends WordSpec with Matchers with Before
     """.stripMargin
 
   val support = new SerializerSpecSupport(
-    ReplicationConfig.create("A", 2552),
-    ReplicationConfig.create("B", 2553, config))
+    ReplicationConfig.create(2552),
+    ReplicationConfig.create(2553, config))
 
   override def afterAll(): Unit =
     support.shutdown()

--- a/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializerSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializerSpec.scala
@@ -31,29 +31,29 @@ object ReplicationProtocolSerializerSpec {
     GetReplicationEndpointInfoSuccess(ReplicationEndpointInfo("A", Set("B", "C")))
 
   val replicationRead1 =
-    ReplicationRead(17L, 10, filter1(), "A", 1)
+    ReplicationRead(17L, 10, filter1(), "A")
 
   val replicationRead2 =
-    ReplicationRead(17L, 10, filter3, "A", 1)
+    ReplicationRead(17L, 10, filter3, "A")
 
   val replicationReadSuccess =
     ReplicationReadSuccess(List(
       DurableEvent("a", 12L, VectorTime(), "r1"),
-      DurableEvent("b", 13L, VectorTime(), "r2")), 27L, "B", 3)
+      DurableEvent("b", 13L, VectorTime(), "r2")), 27L, "B")
 
   val replicationReadFailure =
-    ReplicationReadFailure("test", "B", 3)
+    ReplicationReadFailure("test", "B")
 
   def subscribeReplicator(replicator: ActorRef) =
-    SubscribeReplicator("B", replicator, filter1())
+    SubscribeReplicator("A", "B", replicator, filter1())
 }
 
 class ReplicationProtocolSerializerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   import ReplicationProtocolSerializerSpec._
 
   val support = new SerializerSpecSupport(
-    ReplicationConfig.create("A", 2552),
-    ReplicationConfig.create("B", 2553))
+    ReplicationConfig.create(2552),
+    ReplicationConfig.create(2553))
 
   override def afterAll(): Unit =
     support.shutdown()

--- a/src/main/java/com/rbmhtechnology/eventuate/serializer/DurableEventFormats.java
+++ b/src/main/java/com/rbmhtechnology/eventuate/serializer/DurableEventFormats.java
@@ -24,6 +24,932 @@ public final class DurableEventFormats {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
+  public interface DurableEventBatchFormatOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // repeated .DurableEventFormat events = 1;
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> 
+        getEventsList();
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat getEvents(int index);
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    int getEventsCount();
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    java.util.List<? extends com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder> 
+        getEventsOrBuilderList();
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder getEventsOrBuilder(
+        int index);
+
+    // optional string sourceLogId = 2;
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    boolean hasSourceLogId();
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    java.lang.String getSourceLogId();
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getSourceLogIdBytes();
+
+    // optional int64 lastSourceLogSequenceNrRead = 3;
+    /**
+     * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+     */
+    boolean hasLastSourceLogSequenceNrRead();
+    /**
+     * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+     */
+    long getLastSourceLogSequenceNrRead();
+  }
+  /**
+   * Protobuf type {@code DurableEventBatchFormat}
+   */
+  public static final class DurableEventBatchFormat extends
+      com.google.protobuf.GeneratedMessage
+      implements DurableEventBatchFormatOrBuilder {
+    // Use DurableEventBatchFormat.newBuilder() to construct.
+    private DurableEventBatchFormat(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private DurableEventBatchFormat(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final DurableEventBatchFormat defaultInstance;
+    public static DurableEventBatchFormat getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public DurableEventBatchFormat getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DurableEventBatchFormat(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                events_ = new java.util.ArrayList<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              events_.add(input.readMessage(com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.PARSER, extensionRegistry));
+              break;
+            }
+            case 18: {
+              bitField0_ |= 0x00000001;
+              sourceLogId_ = input.readBytes();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000002;
+              lastSourceLogSequenceNrRead_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          events_ = java.util.Collections.unmodifiableList(events_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.internal_static_DurableEventBatchFormat_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.internal_static_DurableEventBatchFormat_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.class, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<DurableEventBatchFormat> PARSER =
+        new com.google.protobuf.AbstractParser<DurableEventBatchFormat>() {
+      public DurableEventBatchFormat parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new DurableEventBatchFormat(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DurableEventBatchFormat> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    // repeated .DurableEventFormat events = 1;
+    public static final int EVENTS_FIELD_NUMBER = 1;
+    private java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> events_;
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    public java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> getEventsList() {
+      return events_;
+    }
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    public java.util.List<? extends com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder> 
+        getEventsOrBuilderList() {
+      return events_;
+    }
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    public int getEventsCount() {
+      return events_.size();
+    }
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat getEvents(int index) {
+      return events_.get(index);
+    }
+    /**
+     * <code>repeated .DurableEventFormat events = 1;</code>
+     */
+    public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder getEventsOrBuilder(
+        int index) {
+      return events_.get(index);
+    }
+
+    // optional string sourceLogId = 2;
+    public static final int SOURCELOGID_FIELD_NUMBER = 2;
+    private java.lang.Object sourceLogId_;
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    public boolean hasSourceLogId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    public java.lang.String getSourceLogId() {
+      java.lang.Object ref = sourceLogId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          sourceLogId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string sourceLogId = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSourceLogIdBytes() {
+      java.lang.Object ref = sourceLogId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        sourceLogId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional int64 lastSourceLogSequenceNrRead = 3;
+    public static final int LASTSOURCELOGSEQUENCENRREAD_FIELD_NUMBER = 3;
+    private long lastSourceLogSequenceNrRead_;
+    /**
+     * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+     */
+    public boolean hasLastSourceLogSequenceNrRead() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+     */
+    public long getLastSourceLogSequenceNrRead() {
+      return lastSourceLogSequenceNrRead_;
+    }
+
+    private void initFields() {
+      events_ = java.util.Collections.emptyList();
+      sourceLogId_ = "";
+      lastSourceLogSequenceNrRead_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      for (int i = 0; i < getEventsCount(); i++) {
+        if (!getEvents(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < events_.size(); i++) {
+        output.writeMessage(1, events_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(2, getSourceLogIdBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(3, lastSourceLogSequenceNrRead_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < events_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, events_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getSourceLogIdBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, lastSourceLogSequenceNrRead_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code DurableEventBatchFormat}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormatOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.internal_static_DurableEventBatchFormat_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.internal_static_DurableEventBatchFormat_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.class, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.Builder.class);
+      }
+
+      // Construct using com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getEventsFieldBuilder();
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        if (eventsBuilder_ == null) {
+          events_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          eventsBuilder_.clear();
+        }
+        sourceLogId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        lastSourceLogSequenceNrRead_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.internal_static_DurableEventBatchFormat_descriptor;
+      }
+
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat getDefaultInstanceForType() {
+        return com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.getDefaultInstance();
+      }
+
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat build() {
+        com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat buildPartial() {
+        com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat result = new com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (eventsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            events_ = java.util.Collections.unmodifiableList(events_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.events_ = events_;
+        } else {
+          result.events_ = eventsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.sourceLogId_ = sourceLogId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.lastSourceLogSequenceNrRead_ = lastSourceLogSequenceNrRead_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat) {
+          return mergeFrom((com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat other) {
+        if (other == com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat.getDefaultInstance()) return this;
+        if (eventsBuilder_ == null) {
+          if (!other.events_.isEmpty()) {
+            if (events_.isEmpty()) {
+              events_ = other.events_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureEventsIsMutable();
+              events_.addAll(other.events_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.events_.isEmpty()) {
+            if (eventsBuilder_.isEmpty()) {
+              eventsBuilder_.dispose();
+              eventsBuilder_ = null;
+              events_ = other.events_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              eventsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getEventsFieldBuilder() : null;
+            } else {
+              eventsBuilder_.addAllMessages(other.events_);
+            }
+          }
+        }
+        if (other.hasSourceLogId()) {
+          bitField0_ |= 0x00000002;
+          sourceLogId_ = other.sourceLogId_;
+          onChanged();
+        }
+        if (other.hasLastSourceLogSequenceNrRead()) {
+          setLastSourceLogSequenceNrRead(other.getLastSourceLogSequenceNrRead());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        for (int i = 0; i < getEventsCount(); i++) {
+          if (!getEvents(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventBatchFormat) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // repeated .DurableEventFormat events = 1;
+      private java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> events_ =
+        java.util.Collections.emptyList();
+      private void ensureEventsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          events_ = new java.util.ArrayList<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat>(events_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder> eventsBuilder_;
+
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> getEventsList() {
+        if (eventsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(events_);
+        } else {
+          return eventsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public int getEventsCount() {
+        if (eventsBuilder_ == null) {
+          return events_.size();
+        } else {
+          return eventsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat getEvents(int index) {
+        if (eventsBuilder_ == null) {
+          return events_.get(index);
+        } else {
+          return eventsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder setEvents(
+          int index, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat value) {
+        if (eventsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEventsIsMutable();
+          events_.set(index, value);
+          onChanged();
+        } else {
+          eventsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder setEvents(
+          int index, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder builderForValue) {
+        if (eventsBuilder_ == null) {
+          ensureEventsIsMutable();
+          events_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          eventsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder addEvents(com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat value) {
+        if (eventsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEventsIsMutable();
+          events_.add(value);
+          onChanged();
+        } else {
+          eventsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder addEvents(
+          int index, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat value) {
+        if (eventsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEventsIsMutable();
+          events_.add(index, value);
+          onChanged();
+        } else {
+          eventsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder addEvents(
+          com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder builderForValue) {
+        if (eventsBuilder_ == null) {
+          ensureEventsIsMutable();
+          events_.add(builderForValue.build());
+          onChanged();
+        } else {
+          eventsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder addEvents(
+          int index, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder builderForValue) {
+        if (eventsBuilder_ == null) {
+          ensureEventsIsMutable();
+          events_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          eventsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder addAllEvents(
+          java.lang.Iterable<? extends com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat> values) {
+        if (eventsBuilder_ == null) {
+          ensureEventsIsMutable();
+          super.addAll(values, events_);
+          onChanged();
+        } else {
+          eventsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder clearEvents() {
+        if (eventsBuilder_ == null) {
+          events_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          eventsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public Builder removeEvents(int index) {
+        if (eventsBuilder_ == null) {
+          ensureEventsIsMutable();
+          events_.remove(index);
+          onChanged();
+        } else {
+          eventsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder getEventsBuilder(
+          int index) {
+        return getEventsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder getEventsOrBuilder(
+          int index) {
+        if (eventsBuilder_ == null) {
+          return events_.get(index);  } else {
+          return eventsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public java.util.List<? extends com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder> 
+           getEventsOrBuilderList() {
+        if (eventsBuilder_ != null) {
+          return eventsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(events_);
+        }
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder addEventsBuilder() {
+        return getEventsFieldBuilder().addBuilder(
+            com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder addEventsBuilder(
+          int index) {
+        return getEventsFieldBuilder().addBuilder(
+            index, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .DurableEventFormat events = 1;</code>
+       */
+      public java.util.List<com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder> 
+           getEventsBuilderList() {
+        return getEventsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder> 
+          getEventsFieldBuilder() {
+        if (eventsBuilder_ == null) {
+          eventsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormat.Builder, com.rbmhtechnology.eventuate.serializer.DurableEventFormats.DurableEventFormatOrBuilder>(
+                  events_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          events_ = null;
+        }
+        return eventsBuilder_;
+      }
+
+      // optional string sourceLogId = 2;
+      private java.lang.Object sourceLogId_ = "";
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public boolean hasSourceLogId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public java.lang.String getSourceLogId() {
+        java.lang.Object ref = sourceLogId_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          sourceLogId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSourceLogIdBytes() {
+        java.lang.Object ref = sourceLogId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          sourceLogId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public Builder setSourceLogId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        sourceLogId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public Builder clearSourceLogId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        sourceLogId_ = getDefaultInstance().getSourceLogId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sourceLogId = 2;</code>
+       */
+      public Builder setSourceLogIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        sourceLogId_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional int64 lastSourceLogSequenceNrRead = 3;
+      private long lastSourceLogSequenceNrRead_ ;
+      /**
+       * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+       */
+      public boolean hasLastSourceLogSequenceNrRead() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+       */
+      public long getLastSourceLogSequenceNrRead() {
+        return lastSourceLogSequenceNrRead_;
+      }
+      /**
+       * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+       */
+      public Builder setLastSourceLogSequenceNrRead(long value) {
+        bitField0_ |= 0x00000004;
+        lastSourceLogSequenceNrRead_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 lastSourceLogSequenceNrRead = 3;</code>
+       */
+      public Builder clearLastSourceLogSequenceNrRead() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        lastSourceLogSequenceNrRead_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:DurableEventBatchFormat)
+    }
+
+    static {
+      defaultInstance = new DurableEventBatchFormat(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:DurableEventBatchFormat)
+  }
+
   public interface DurableEventFormatOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -3606,6 +4532,11 @@ public final class DurableEventFormats {
   }
 
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_DurableEventBatchFormat_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_DurableEventBatchFormat_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_DurableEventFormat_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -3635,47 +4566,56 @@ public final class DurableEventFormats {
   static {
     java.lang.String[] descriptorData = {
       "\n+src/main/protobuf/DurableEventFormats." +
-      "proto\"\267\002\n\022DurableEventFormat\022\037\n\007payload\030" +
-      "\001 \001(\0132\016.PayloadFormat\022\027\n\017systemTimestamp" +
-      "\030\002 \001(\003\022*\n\017vectorTimestamp\030\003 \001(\0132\021.Vector" +
-      "TimeFormat\022\030\n\020emitterReplicaId\030\004 \001(\t\022\032\n\022" +
-      "emitterAggregateId\030\005 \001(\t\022!\n\031customRoutin" +
-      "gDestinations\030\006 \003(\t\022\023\n\013sourceLogId\030\007 \001(\t" +
-      "\022\023\n\013targetLogId\030\010 \001(\t\022\033\n\023sourceLogSequen" +
-      "ceNr\030\t \001(\003\022\033\n\023targetLogSequenceNr\030\n \001(\003\"" +
-      "O\n\rPayloadFormat\022\024\n\014serializerId\030\001 \001(\005\022\017",
-      "\n\007payload\030\002 \001(\014\022\027\n\017payloadManifest\030\003 \001(\014" +
-      "\"?\n\025VectorTimeEntryFormat\022\021\n\tprocessId\030\001" +
-      " \002(\t\022\023\n\013logicalTime\030\002 \002(\003\";\n\020VectorTimeF" +
-      "ormat\022\'\n\007entries\030\001 \003(\0132\026.VectorTimeEntry" +
-      "FormatB+\n\'com.rbmhtechnology.eventuate.s" +
-      "erializerH\001"
+      "proto\"x\n\027DurableEventBatchFormat\022#\n\006even" +
+      "ts\030\001 \003(\0132\023.DurableEventFormat\022\023\n\013sourceL" +
+      "ogId\030\002 \001(\t\022#\n\033lastSourceLogSequenceNrRea" +
+      "d\030\003 \001(\003\"\267\002\n\022DurableEventFormat\022\037\n\007payloa" +
+      "d\030\001 \001(\0132\016.PayloadFormat\022\027\n\017systemTimesta" +
+      "mp\030\002 \001(\003\022*\n\017vectorTimestamp\030\003 \001(\0132\021.Vect" +
+      "orTimeFormat\022\030\n\020emitterReplicaId\030\004 \001(\t\022\032" +
+      "\n\022emitterAggregateId\030\005 \001(\t\022!\n\031customRout" +
+      "ingDestinations\030\006 \003(\t\022\023\n\013sourceLogId\030\007 \001",
+      "(\t\022\023\n\013targetLogId\030\010 \001(\t\022\033\n\023sourceLogSequ" +
+      "enceNr\030\t \001(\003\022\033\n\023targetLogSequenceNr\030\n \001(" +
+      "\003\"O\n\rPayloadFormat\022\024\n\014serializerId\030\001 \001(\005" +
+      "\022\017\n\007payload\030\002 \001(\014\022\027\n\017payloadManifest\030\003 \001" +
+      "(\014\"?\n\025VectorTimeEntryFormat\022\021\n\tprocessId" +
+      "\030\001 \002(\t\022\023\n\013logicalTime\030\002 \002(\003\";\n\020VectorTim" +
+      "eFormat\022\'\n\007entries\030\001 \003(\0132\026.VectorTimeEnt" +
+      "ryFormatB+\n\'com.rbmhtechnology.eventuate" +
+      ".serializerH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
         public com.google.protobuf.ExtensionRegistry assignDescriptors(
             com.google.protobuf.Descriptors.FileDescriptor root) {
           descriptor = root;
-          internal_static_DurableEventFormat_descriptor =
+          internal_static_DurableEventBatchFormat_descriptor =
             getDescriptor().getMessageTypes().get(0);
+          internal_static_DurableEventBatchFormat_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_DurableEventBatchFormat_descriptor,
+              new java.lang.String[] { "Events", "SourceLogId", "LastSourceLogSequenceNrRead", });
+          internal_static_DurableEventFormat_descriptor =
+            getDescriptor().getMessageTypes().get(1);
           internal_static_DurableEventFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_DurableEventFormat_descriptor,
               new java.lang.String[] { "Payload", "SystemTimestamp", "VectorTimestamp", "EmitterReplicaId", "EmitterAggregateId", "CustomRoutingDestinations", "SourceLogId", "TargetLogId", "SourceLogSequenceNr", "TargetLogSequenceNr", });
           internal_static_PayloadFormat_descriptor =
-            getDescriptor().getMessageTypes().get(1);
+            getDescriptor().getMessageTypes().get(2);
           internal_static_PayloadFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PayloadFormat_descriptor,
               new java.lang.String[] { "SerializerId", "Payload", "PayloadManifest", });
           internal_static_VectorTimeEntryFormat_descriptor =
-            getDescriptor().getMessageTypes().get(2);
+            getDescriptor().getMessageTypes().get(3);
           internal_static_VectorTimeEntryFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_VectorTimeEntryFormat_descriptor,
               new java.lang.String[] { "ProcessId", "LogicalTime", });
           internal_static_VectorTimeFormat_descriptor =
-            getDescriptor().getMessageTypes().get(3);
+            getDescriptor().getMessageTypes().get(4);
           internal_static_VectorTimeFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_VectorTimeFormat_descriptor,

--- a/src/main/java/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolFormats.java
+++ b/src/main/java/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolFormats.java
@@ -1579,16 +1579,6 @@ public final class ReplicationProtocolFormats {
      */
     com.google.protobuf.ByteString
         getTargetLogIdBytes();
-
-    // optional int32 correlationId = 5;
-    /**
-     * <code>optional int32 correlationId = 5;</code>
-     */
-    boolean hasCorrelationId();
-    /**
-     * <code>optional int32 correlationId = 5;</code>
-     */
-    int getCorrelationId();
   }
   /**
    * Protobuf type {@code ReplicationReadFormat}
@@ -1667,11 +1657,6 @@ public final class ReplicationProtocolFormats {
             case 34: {
               bitField0_ |= 0x00000008;
               targetLogId_ = input.readBytes();
-              break;
-            }
-            case 40: {
-              bitField0_ |= 0x00000010;
-              correlationId_ = input.readInt32();
               break;
             }
           }
@@ -1811,28 +1796,11 @@ public final class ReplicationProtocolFormats {
       }
     }
 
-    // optional int32 correlationId = 5;
-    public static final int CORRELATIONID_FIELD_NUMBER = 5;
-    private int correlationId_;
-    /**
-     * <code>optional int32 correlationId = 5;</code>
-     */
-    public boolean hasCorrelationId() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
-    }
-    /**
-     * <code>optional int32 correlationId = 5;</code>
-     */
-    public int getCorrelationId() {
-      return correlationId_;
-    }
-
     private void initFields() {
       fromSequenceNr_ = 0L;
       maxNumEvents_ = 0;
       filter_ = com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.getDefaultInstance();
       targetLogId_ = "";
-      correlationId_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1864,9 +1832,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeBytes(4, getTargetLogIdBytes());
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        output.writeInt32(5, correlationId_);
-      }
       getUnknownFields().writeTo(output);
     }
 
@@ -1891,10 +1856,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, getTargetLogIdBytes());
-      }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(5, correlationId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2025,8 +1986,6 @@ public final class ReplicationProtocolFormats {
         bitField0_ = (bitField0_ & ~0x00000004);
         targetLogId_ = "";
         bitField0_ = (bitField0_ & ~0x00000008);
-        correlationId_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -2075,10 +2034,6 @@ public final class ReplicationProtocolFormats {
           to_bitField0_ |= 0x00000008;
         }
         result.targetLogId_ = targetLogId_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-          to_bitField0_ |= 0x00000010;
-        }
-        result.correlationId_ = correlationId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2108,9 +2063,6 @@ public final class ReplicationProtocolFormats {
           bitField0_ |= 0x00000008;
           targetLogId_ = other.targetLogId_;
           onChanged();
-        }
-        if (other.hasCorrelationId()) {
-          setCorrelationId(other.getCorrelationId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -2402,39 +2354,6 @@ public final class ReplicationProtocolFormats {
         return this;
       }
 
-      // optional int32 correlationId = 5;
-      private int correlationId_ ;
-      /**
-       * <code>optional int32 correlationId = 5;</code>
-       */
-      public boolean hasCorrelationId() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
-      }
-      /**
-       * <code>optional int32 correlationId = 5;</code>
-       */
-      public int getCorrelationId() {
-        return correlationId_;
-      }
-      /**
-       * <code>optional int32 correlationId = 5;</code>
-       */
-      public Builder setCorrelationId(int value) {
-        bitField0_ |= 0x00000010;
-        correlationId_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional int32 correlationId = 5;</code>
-       */
-      public Builder clearCorrelationId() {
-        bitField0_ = (bitField0_ & ~0x00000010);
-        correlationId_ = 0;
-        onChanged();
-        return this;
-      }
-
       // @@protoc_insertion_point(builder_scope:ReplicationReadFormat)
     }
 
@@ -2498,16 +2417,6 @@ public final class ReplicationProtocolFormats {
      */
     com.google.protobuf.ByteString
         getTargetLogIdBytes();
-
-    // optional int32 correlationId = 4;
-    /**
-     * <code>optional int32 correlationId = 4;</code>
-     */
-    boolean hasCorrelationId();
-    /**
-     * <code>optional int32 correlationId = 4;</code>
-     */
-    int getCorrelationId();
   }
   /**
    * Protobuf type {@code ReplicationReadSuccessFormat}
@@ -2576,11 +2485,6 @@ public final class ReplicationProtocolFormats {
             case 26: {
               bitField0_ |= 0x00000002;
               targetLogId_ = input.readBytes();
-              break;
-            }
-            case 32: {
-              bitField0_ |= 0x00000004;
-              correlationId_ = input.readInt32();
               break;
             }
           }
@@ -2721,27 +2625,10 @@ public final class ReplicationProtocolFormats {
       }
     }
 
-    // optional int32 correlationId = 4;
-    public static final int CORRELATIONID_FIELD_NUMBER = 4;
-    private int correlationId_;
-    /**
-     * <code>optional int32 correlationId = 4;</code>
-     */
-    public boolean hasCorrelationId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    /**
-     * <code>optional int32 correlationId = 4;</code>
-     */
-    public int getCorrelationId() {
-      return correlationId_;
-    }
-
     private void initFields() {
       events_ = java.util.Collections.emptyList();
       lastSourceLogSequenceNrRead_ = 0L;
       targetLogId_ = "";
-      correlationId_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2770,9 +2657,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(3, getTargetLogIdBytes());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt32(4, correlationId_);
-      }
       getUnknownFields().writeTo(output);
     }
 
@@ -2793,10 +2677,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, getTargetLogIdBytes());
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(4, correlationId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -2925,8 +2805,6 @@ public final class ReplicationProtocolFormats {
         bitField0_ = (bitField0_ & ~0x00000002);
         targetLogId_ = "";
         bitField0_ = (bitField0_ & ~0x00000004);
-        correlationId_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -2972,10 +2850,6 @@ public final class ReplicationProtocolFormats {
           to_bitField0_ |= 0x00000002;
         }
         result.targetLogId_ = targetLogId_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.correlationId_ = correlationId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3025,9 +2899,6 @@ public final class ReplicationProtocolFormats {
           bitField0_ |= 0x00000004;
           targetLogId_ = other.targetLogId_;
           onChanged();
-        }
-        if (other.hasCorrelationId()) {
-          setCorrelationId(other.getCorrelationId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -3409,39 +3280,6 @@ public final class ReplicationProtocolFormats {
         return this;
       }
 
-      // optional int32 correlationId = 4;
-      private int correlationId_ ;
-      /**
-       * <code>optional int32 correlationId = 4;</code>
-       */
-      public boolean hasCorrelationId() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      /**
-       * <code>optional int32 correlationId = 4;</code>
-       */
-      public int getCorrelationId() {
-        return correlationId_;
-      }
-      /**
-       * <code>optional int32 correlationId = 4;</code>
-       */
-      public Builder setCorrelationId(int value) {
-        bitField0_ |= 0x00000008;
-        correlationId_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional int32 correlationId = 4;</code>
-       */
-      public Builder clearCorrelationId() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        correlationId_ = 0;
-        onChanged();
-        return this;
-      }
-
       // @@protoc_insertion_point(builder_scope:ReplicationReadSuccessFormat)
     }
 
@@ -3485,16 +3323,6 @@ public final class ReplicationProtocolFormats {
      */
     com.google.protobuf.ByteString
         getTargetLogIdBytes();
-
-    // optional int32 correlationId = 3;
-    /**
-     * <code>optional int32 correlationId = 3;</code>
-     */
-    boolean hasCorrelationId();
-    /**
-     * <code>optional int32 correlationId = 3;</code>
-     */
-    int getCorrelationId();
   }
   /**
    * Protobuf type {@code ReplicationReadFailureFormat}
@@ -3555,11 +3383,6 @@ public final class ReplicationProtocolFormats {
             case 18: {
               bitField0_ |= 0x00000002;
               targetLogId_ = input.readBytes();
-              break;
-            }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              correlationId_ = input.readInt32();
               break;
             }
           }
@@ -3688,26 +3511,9 @@ public final class ReplicationProtocolFormats {
       }
     }
 
-    // optional int32 correlationId = 3;
-    public static final int CORRELATIONID_FIELD_NUMBER = 3;
-    private int correlationId_;
-    /**
-     * <code>optional int32 correlationId = 3;</code>
-     */
-    public boolean hasCorrelationId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    /**
-     * <code>optional int32 correlationId = 3;</code>
-     */
-    public int getCorrelationId() {
-      return correlationId_;
-    }
-
     private void initFields() {
       cause_ = "";
       targetLogId_ = "";
-      correlationId_ = 0;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -3727,9 +3533,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, getTargetLogIdBytes());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt32(3, correlationId_);
-      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3746,10 +3549,6 @@ public final class ReplicationProtocolFormats {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, getTargetLogIdBytes());
-      }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(3, correlationId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -3871,8 +3670,6 @@ public final class ReplicationProtocolFormats {
         bitField0_ = (bitField0_ & ~0x00000001);
         targetLogId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        correlationId_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -3909,10 +3706,6 @@ public final class ReplicationProtocolFormats {
           to_bitField0_ |= 0x00000002;
         }
         result.targetLogId_ = targetLogId_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
-        }
-        result.correlationId_ = correlationId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3938,9 +3731,6 @@ public final class ReplicationProtocolFormats {
           bitField0_ |= 0x00000002;
           targetLogId_ = other.targetLogId_;
           onChanged();
-        }
-        if (other.hasCorrelationId()) {
-          setCorrelationId(other.getCorrelationId());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4117,39 +3907,6 @@ public final class ReplicationProtocolFormats {
         return this;
       }
 
-      // optional int32 correlationId = 3;
-      private int correlationId_ ;
-      /**
-       * <code>optional int32 correlationId = 3;</code>
-       */
-      public boolean hasCorrelationId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
-      }
-      /**
-       * <code>optional int32 correlationId = 3;</code>
-       */
-      public int getCorrelationId() {
-        return correlationId_;
-      }
-      /**
-       * <code>optional int32 correlationId = 3;</code>
-       */
-      public Builder setCorrelationId(int value) {
-        bitField0_ |= 0x00000004;
-        correlationId_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional int32 correlationId = 3;</code>
-       */
-      public Builder clearCorrelationId() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        correlationId_ = 0;
-        onChanged();
-        return this;
-      }
-
       // @@protoc_insertion_point(builder_scope:ReplicationReadFailureFormat)
     }
 
@@ -4164,47 +3921,62 @@ public final class ReplicationProtocolFormats {
   public interface SubscribeReplicatorFormatOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
-    // optional string targetLogId = 1;
+    // optional string sourceLogId = 1;
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string sourceLogId = 1;</code>
+     */
+    boolean hasSourceLogId();
+    /**
+     * <code>optional string sourceLogId = 1;</code>
+     */
+    java.lang.String getSourceLogId();
+    /**
+     * <code>optional string sourceLogId = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getSourceLogIdBytes();
+
+    // optional string targetLogId = 2;
+    /**
+     * <code>optional string targetLogId = 2;</code>
      */
     boolean hasTargetLogId();
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string targetLogId = 2;</code>
      */
     java.lang.String getTargetLogId();
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string targetLogId = 2;</code>
      */
     com.google.protobuf.ByteString
         getTargetLogIdBytes();
 
-    // optional string replicator = 2;
+    // optional string replicator = 3;
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     boolean hasReplicator();
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     java.lang.String getReplicator();
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     com.google.protobuf.ByteString
         getReplicatorBytes();
 
-    // optional .ReplicationFilterTreeFormat filter = 3;
+    // optional .ReplicationFilterTreeFormat filter = 4;
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     boolean hasFilter();
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat getFilter();
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormatOrBuilder getFilterOrBuilder();
   }
@@ -4261,17 +4033,22 @@ public final class ReplicationProtocolFormats {
             }
             case 10: {
               bitField0_ |= 0x00000001;
-              targetLogId_ = input.readBytes();
+              sourceLogId_ = input.readBytes();
               break;
             }
             case 18: {
               bitField0_ |= 0x00000002;
-              replicator_ = input.readBytes();
+              targetLogId_ = input.readBytes();
               break;
             }
             case 26: {
+              bitField0_ |= 0x00000004;
+              replicator_ = input.readBytes();
+              break;
+            }
+            case 34: {
               com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000008) == 0x00000008)) {
                 subBuilder = filter_.toBuilder();
               }
               filter_ = input.readMessage(com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.PARSER, extensionRegistry);
@@ -4279,7 +4056,7 @@ public final class ReplicationProtocolFormats {
                 subBuilder.mergeFrom(filter_);
                 filter_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               break;
             }
           }
@@ -4322,17 +4099,60 @@ public final class ReplicationProtocolFormats {
     }
 
     private int bitField0_;
-    // optional string targetLogId = 1;
-    public static final int TARGETLOGID_FIELD_NUMBER = 1;
-    private java.lang.Object targetLogId_;
+    // optional string sourceLogId = 1;
+    public static final int SOURCELOGID_FIELD_NUMBER = 1;
+    private java.lang.Object sourceLogId_;
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string sourceLogId = 1;</code>
      */
-    public boolean hasTargetLogId() {
+    public boolean hasSourceLogId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string sourceLogId = 1;</code>
+     */
+    public java.lang.String getSourceLogId() {
+      java.lang.Object ref = sourceLogId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          sourceLogId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string sourceLogId = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSourceLogIdBytes() {
+      java.lang.Object ref = sourceLogId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        sourceLogId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional string targetLogId = 2;
+    public static final int TARGETLOGID_FIELD_NUMBER = 2;
+    private java.lang.Object targetLogId_;
+    /**
+     * <code>optional string targetLogId = 2;</code>
+     */
+    public boolean hasTargetLogId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string targetLogId = 2;</code>
      */
     public java.lang.String getTargetLogId() {
       java.lang.Object ref = targetLogId_;
@@ -4349,7 +4169,7 @@ public final class ReplicationProtocolFormats {
       }
     }
     /**
-     * <code>optional string targetLogId = 1;</code>
+     * <code>optional string targetLogId = 2;</code>
      */
     public com.google.protobuf.ByteString
         getTargetLogIdBytes() {
@@ -4365,17 +4185,17 @@ public final class ReplicationProtocolFormats {
       }
     }
 
-    // optional string replicator = 2;
-    public static final int REPLICATOR_FIELD_NUMBER = 2;
+    // optional string replicator = 3;
+    public static final int REPLICATOR_FIELD_NUMBER = 3;
     private java.lang.Object replicator_;
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     public boolean hasReplicator() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     public java.lang.String getReplicator() {
       java.lang.Object ref = replicator_;
@@ -4392,7 +4212,7 @@ public final class ReplicationProtocolFormats {
       }
     }
     /**
-     * <code>optional string replicator = 2;</code>
+     * <code>optional string replicator = 3;</code>
      */
     public com.google.protobuf.ByteString
         getReplicatorBytes() {
@@ -4408,29 +4228,30 @@ public final class ReplicationProtocolFormats {
       }
     }
 
-    // optional .ReplicationFilterTreeFormat filter = 3;
-    public static final int FILTER_FIELD_NUMBER = 3;
+    // optional .ReplicationFilterTreeFormat filter = 4;
+    public static final int FILTER_FIELD_NUMBER = 4;
     private com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat filter_;
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     public boolean hasFilter() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     public com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat getFilter() {
       return filter_;
     }
     /**
-     * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+     * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
      */
     public com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormatOrBuilder getFilterOrBuilder() {
       return filter_;
     }
 
     private void initFields() {
+      sourceLogId_ = "";
       targetLogId_ = "";
       replicator_ = "";
       filter_ = com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.getDefaultInstance();
@@ -4454,13 +4275,16 @@ public final class ReplicationProtocolFormats {
                         throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getTargetLogIdBytes());
+        output.writeBytes(1, getSourceLogIdBytes());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getReplicatorBytes());
+        output.writeBytes(2, getTargetLogIdBytes());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeMessage(3, filter_);
+        output.writeBytes(3, getReplicatorBytes());
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeMessage(4, filter_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -4473,15 +4297,19 @@ public final class ReplicationProtocolFormats {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(1, getTargetLogIdBytes());
+          .computeBytesSize(1, getSourceLogIdBytes());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBytesSize(2, getReplicatorBytes());
+          .computeBytesSize(2, getTargetLogIdBytes());
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, filter_);
+          .computeBytesSize(3, getReplicatorBytes());
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(4, filter_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -4600,16 +4428,18 @@ public final class ReplicationProtocolFormats {
 
       public Builder clear() {
         super.clear();
-        targetLogId_ = "";
+        sourceLogId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        replicator_ = "";
+        targetLogId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        replicator_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         if (filterBuilder_ == null) {
           filter_ = com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.getDefaultInstance();
         } else {
           filterBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -4641,13 +4471,17 @@ public final class ReplicationProtocolFormats {
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
           to_bitField0_ |= 0x00000001;
         }
-        result.targetLogId_ = targetLogId_;
+        result.sourceLogId_ = sourceLogId_;
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.replicator_ = replicator_;
+        result.targetLogId_ = targetLogId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
+        }
+        result.replicator_ = replicator_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
         }
         if (filterBuilder_ == null) {
           result.filter_ = filter_;
@@ -4670,13 +4504,18 @@ public final class ReplicationProtocolFormats {
 
       public Builder mergeFrom(com.rbmhtechnology.eventuate.serializer.ReplicationProtocolFormats.SubscribeReplicatorFormat other) {
         if (other == com.rbmhtechnology.eventuate.serializer.ReplicationProtocolFormats.SubscribeReplicatorFormat.getDefaultInstance()) return this;
-        if (other.hasTargetLogId()) {
+        if (other.hasSourceLogId()) {
           bitField0_ |= 0x00000001;
+          sourceLogId_ = other.sourceLogId_;
+          onChanged();
+        }
+        if (other.hasTargetLogId()) {
+          bitField0_ |= 0x00000002;
           targetLogId_ = other.targetLogId_;
           onChanged();
         }
         if (other.hasReplicator()) {
-          bitField0_ |= 0x00000002;
+          bitField0_ |= 0x00000004;
           replicator_ = other.replicator_;
           onChanged();
         }
@@ -4716,16 +4555,90 @@ public final class ReplicationProtocolFormats {
       }
       private int bitField0_;
 
-      // optional string targetLogId = 1;
-      private java.lang.Object targetLogId_ = "";
+      // optional string sourceLogId = 1;
+      private java.lang.Object sourceLogId_ = "";
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string sourceLogId = 1;</code>
        */
-      public boolean hasTargetLogId() {
+      public boolean hasSourceLogId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string sourceLogId = 1;</code>
+       */
+      public java.lang.String getSourceLogId() {
+        java.lang.Object ref = sourceLogId_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          sourceLogId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string sourceLogId = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSourceLogIdBytes() {
+        java.lang.Object ref = sourceLogId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          sourceLogId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string sourceLogId = 1;</code>
+       */
+      public Builder setSourceLogId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        sourceLogId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sourceLogId = 1;</code>
+       */
+      public Builder clearSourceLogId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        sourceLogId_ = getDefaultInstance().getSourceLogId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sourceLogId = 1;</code>
+       */
+      public Builder setSourceLogIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        sourceLogId_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional string targetLogId = 2;
+      private java.lang.Object targetLogId_ = "";
+      /**
+       * <code>optional string targetLogId = 2;</code>
+       */
+      public boolean hasTargetLogId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string targetLogId = 2;</code>
        */
       public java.lang.String getTargetLogId() {
         java.lang.Object ref = targetLogId_;
@@ -4739,7 +4652,7 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string targetLogId = 2;</code>
        */
       public com.google.protobuf.ByteString
           getTargetLogIdBytes() {
@@ -4755,51 +4668,51 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string targetLogId = 2;</code>
        */
       public Builder setTargetLogId(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000001;
+  bitField0_ |= 0x00000002;
         targetLogId_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string targetLogId = 2;</code>
        */
       public Builder clearTargetLogId() {
-        bitField0_ = (bitField0_ & ~0x00000001);
+        bitField0_ = (bitField0_ & ~0x00000002);
         targetLogId_ = getDefaultInstance().getTargetLogId();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string targetLogId = 1;</code>
+       * <code>optional string targetLogId = 2;</code>
        */
       public Builder setTargetLogIdBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000001;
+  bitField0_ |= 0x00000002;
         targetLogId_ = value;
         onChanged();
         return this;
       }
 
-      // optional string replicator = 2;
+      // optional string replicator = 3;
       private java.lang.Object replicator_ = "";
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public boolean hasReplicator() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public java.lang.String getReplicator() {
         java.lang.Object ref = replicator_;
@@ -4813,7 +4726,7 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public com.google.protobuf.ByteString
           getReplicatorBytes() {
@@ -4829,53 +4742,53 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public Builder setReplicator(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         replicator_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public Builder clearReplicator() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         replicator_ = getDefaultInstance().getReplicator();
         onChanged();
         return this;
       }
       /**
-       * <code>optional string replicator = 2;</code>
+       * <code>optional string replicator = 3;</code>
        */
       public Builder setReplicatorBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         replicator_ = value;
         onChanged();
         return this;
       }
 
-      // optional .ReplicationFilterTreeFormat filter = 3;
+      // optional .ReplicationFilterTreeFormat filter = 4;
       private com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat filter_ = com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
           com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat, com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.Builder, com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormatOrBuilder> filterBuilder_;
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public boolean hasFilter() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat getFilter() {
         if (filterBuilder_ == null) {
@@ -4885,7 +4798,7 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public Builder setFilter(com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat value) {
         if (filterBuilder_ == null) {
@@ -4897,11 +4810,11 @@ public final class ReplicationProtocolFormats {
         } else {
           filterBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         return this;
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public Builder setFilter(
           com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.Builder builderForValue) {
@@ -4911,15 +4824,15 @@ public final class ReplicationProtocolFormats {
         } else {
           filterBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         return this;
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public Builder mergeFilter(com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat value) {
         if (filterBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000008) == 0x00000008) &&
               filter_ != com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.getDefaultInstance()) {
             filter_ =
               com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.newBuilder(filter_).mergeFrom(value).buildPartial();
@@ -4930,11 +4843,11 @@ public final class ReplicationProtocolFormats {
         } else {
           filterBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         return this;
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public Builder clearFilter() {
         if (filterBuilder_ == null) {
@@ -4943,19 +4856,19 @@ public final class ReplicationProtocolFormats {
         } else {
           filterBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.Builder getFilterBuilder() {
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         onChanged();
         return getFilterFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       public com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormatOrBuilder getFilterOrBuilder() {
         if (filterBuilder_ != null) {
@@ -4965,7 +4878,7 @@ public final class ReplicationProtocolFormats {
         }
       }
       /**
-       * <code>optional .ReplicationFilterTreeFormat filter = 3;</code>
+       * <code>optional .ReplicationFilterTreeFormat filter = 4;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat, com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormat.Builder, com.rbmhtechnology.eventuate.serializer.ReplicationFilterFormats.ReplicationFilterTreeFormatOrBuilder> 
@@ -5366,22 +5279,21 @@ public final class ReplicationProtocolFormats {
       "\022\020\n\010logNames\030\002 \003(\t\"\"\n GetReplicationEndp" +
       "ointInfoFormat\"W\n\'GetReplicationEndpoint" +
       "InfoSuccessFormat\022,\n\004info\030\001 \002(\0132\036.Replic" +
-      "ationEndpointInfoFormat\"\237\001\n\025ReplicationR" +
+      "ationEndpointInfoFormat\"\210\001\n\025ReplicationR" +
       "eadFormat\022\026\n\016fromSequenceNr\030\001 \001(\003\022\024\n\014max",
       "NumEvents\030\002 \001(\005\022,\n\006filter\030\003 \001(\0132\034.Replic" +
       "ationFilterTreeFormat\022\023\n\013targetLogId\030\004 \001" +
-      "(\t\022\025\n\rcorrelationId\030\005 \001(\005\"\224\001\n\034Replicatio" +
-      "nReadSuccessFormat\022#\n\006events\030\001 \003(\0132\023.Dur" +
-      "ableEventFormat\022#\n\033lastSourceLogSequence" +
-      "NrRead\030\002 \001(\003\022\023\n\013targetLogId\030\003 \001(\t\022\025\n\rcor" +
-      "relationId\030\004 \001(\005\"Y\n\034ReplicationReadFailu" +
-      "reFormat\022\r\n\005cause\030\001 \001(\t\022\023\n\013targetLogId\030\002" +
-      " \001(\t\022\025\n\rcorrelationId\030\003 \001(\005\"r\n\031Subscribe" +
-      "ReplicatorFormat\022\023\n\013targetLogId\030\001 \001(\t\022\022\n",
-      "\nreplicator\030\002 \001(\t\022,\n\006filter\030\003 \001(\0132\034.Repl" +
-      "icationFilterTreeFormat\"\026\n\024ReplicationDu" +
-      "eFormatB+\n\'com.rbmhtechnology.eventuate." +
-      "serializerH\001"
+      "(\t\"}\n\034ReplicationReadSuccessFormat\022#\n\006ev" +
+      "ents\030\001 \003(\0132\023.DurableEventFormat\022#\n\033lastS" +
+      "ourceLogSequenceNrRead\030\002 \001(\003\022\023\n\013targetLo" +
+      "gId\030\003 \001(\t\"B\n\034ReplicationReadFailureForma" +
+      "t\022\r\n\005cause\030\001 \001(\t\022\023\n\013targetLogId\030\002 \001(\t\"\207\001" +
+      "\n\031SubscribeReplicatorFormat\022\023\n\013sourceLog" +
+      "Id\030\001 \001(\t\022\023\n\013targetLogId\030\002 \001(\t\022\022\n\nreplica" +
+      "tor\030\003 \001(\t\022,\n\006filter\030\004 \001(\0132\034.ReplicationF",
+      "ilterTreeFormat\"\026\n\024ReplicationDueFormatB" +
+      "+\n\'com.rbmhtechnology.eventuate.serializ" +
+      "erH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -5411,25 +5323,25 @@ public final class ReplicationProtocolFormats {
           internal_static_ReplicationReadFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ReplicationReadFormat_descriptor,
-              new java.lang.String[] { "FromSequenceNr", "MaxNumEvents", "Filter", "TargetLogId", "CorrelationId", });
+              new java.lang.String[] { "FromSequenceNr", "MaxNumEvents", "Filter", "TargetLogId", });
           internal_static_ReplicationReadSuccessFormat_descriptor =
             getDescriptor().getMessageTypes().get(4);
           internal_static_ReplicationReadSuccessFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ReplicationReadSuccessFormat_descriptor,
-              new java.lang.String[] { "Events", "LastSourceLogSequenceNrRead", "TargetLogId", "CorrelationId", });
+              new java.lang.String[] { "Events", "LastSourceLogSequenceNrRead", "TargetLogId", });
           internal_static_ReplicationReadFailureFormat_descriptor =
             getDescriptor().getMessageTypes().get(5);
           internal_static_ReplicationReadFailureFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ReplicationReadFailureFormat_descriptor,
-              new java.lang.String[] { "Cause", "TargetLogId", "CorrelationId", });
+              new java.lang.String[] { "Cause", "TargetLogId", });
           internal_static_SubscribeReplicatorFormat_descriptor =
             getDescriptor().getMessageTypes().get(6);
           internal_static_SubscribeReplicatorFormat_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_SubscribeReplicatorFormat_descriptor,
-              new java.lang.String[] { "TargetLogId", "Replicator", "Filter", });
+              new java.lang.String[] { "SourceLogId", "TargetLogId", "Replicator", "Filter", });
           internal_static_ReplicationDueFormat_descriptor =
             getDescriptor().getMessageTypes().get(7);
           internal_static_ReplicationDueFormat_fieldAccessorTable = new

--- a/src/main/protobuf/DurableEventFormats.proto
+++ b/src/main/protobuf/DurableEventFormats.proto
@@ -21,6 +21,12 @@
 option java_package = "com.rbmhtechnology.eventuate.serializer";
 option optimize_for = SPEED;
 
+message DurableEventBatchFormat {
+  repeated DurableEventFormat events = 1;
+  optional string sourceLogId = 2;
+  optional int64 lastSourceLogSequenceNrRead = 3;
+}
+
 message DurableEventFormat {
   optional PayloadFormat payload = 1;
   optional int64 systemTimestamp = 2;

--- a/src/main/protobuf/ReplicationProtocolFormats.proto
+++ b/src/main/protobuf/ReplicationProtocolFormats.proto
@@ -42,26 +42,24 @@ message ReplicationReadFormat {
   optional int32 maxNumEvents = 2;
   optional ReplicationFilterTreeFormat filter = 3;
   optional string targetLogId = 4;
-  optional int32 correlationId = 5;
 }
 
 message ReplicationReadSuccessFormat {
   repeated DurableEventFormat events = 1;
   optional int64 lastSourceLogSequenceNrRead = 2;
   optional string targetLogId = 3;
-  optional int32 correlationId = 4;
 }
 
 message ReplicationReadFailureFormat {
   optional string cause = 1;
   optional string targetLogId = 2;
-  optional int32 correlationId = 3;
 }
 
 message SubscribeReplicatorFormat {
-  optional string targetLogId = 1;
-  optional string replicator = 2;
-  optional ReplicationFilterTreeFormat filter = 3;
+  optional string sourceLogId = 1;
+  optional string targetLogId = 2;
+  optional string replicator = 3;
+  optional ReplicationFilterTreeFormat filter = 4;
 }
 
 message ReplicationDueFormat {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -8,6 +8,7 @@ akka {
 
     serialization-bindings {
       "com.rbmhtechnology.eventuate.DurableEvent" = eventuate-durable-event
+      "com.rbmhtechnology.eventuate.DurableEventBatch" = eventuate-durable-event
       "com.rbmhtechnology.eventuate.ReplicationFilter$Format" = eventuate-replication-filter
       "com.rbmhtechnology.eventuate.ReplicationProtocol$Format" = eventuate-replication-protocol
     }
@@ -28,8 +29,14 @@ eventuate {
     batch-size-max = 200
 
     # Event replication retry interval. Event replication is re-tried at this
-    # interval if previous transfer batch was empty.
+    # interval if previous transfer batch was empty or failed.
     retry-interval = 5s
+
+    # Timeout for reading events from the remote source log.
+    read-timeout = 10s
+
+    # Timeout for writing events to the local target log.
+    write-timeout = 10s
 
     # Maximum duration of missing heartbeats from a remote location until
     # that location is considered unavailable.
@@ -43,19 +50,71 @@ eventuate {
     # Use fsync on write.
     fsync = on
 
-    # Dispatcher for writes.
     write-dispatcher {
       executor = "thread-pool-executor"
       type = PinnedDispatcher
     }
 
-    # Dispatcher for reads.
     read-dispatcher {
       type = Dispatcher
       executor = "fork-join-executor"
       fork-join-executor {
         parallelism-min = 2
         parallelism-max = 8
+      }
+    }
+  }
+
+  log.cassandra {
+    # Comma-separated list of contact points in the cluster (comma-separated
+    # hostname or hostname:port list).
+    contact-points = ["127.0.0.1"]
+
+    # Default port of contact points in the cluster. Ports defined in
+    # contact-points override this setting.
+    default-port = 9042
+
+    # Name of the keyspace created/used by Eventuate.
+    keyspace = "eventuate"
+
+    # Whether or not to auto-create the keyspace.
+    keyspace-autocreate = true
+
+    # Prefix of all tables created/used by Eventuate.
+    table-prefix = "log"
+
+    # Replication factor to use when creating the keyspace.
+    replication-factor = 1
+
+    # Write consistency level
+    write-consistency = "QUORUM"
+
+    # Read consistency level
+    read-consistency = "QUORUM"
+
+    # Maximum number of rows in a result set.
+    max-result-set-size = 1000
+
+    # Retry backoff for event log initialization. Initialization requires
+    # reading the last indexed sequence number and indexing of not yet
+    # indexed log entries.
+    init-retry-backoff = 5s
+
+    # Number of new events that must have been written before another index
+    # update is triggered.
+    index-update-limit = 100
+
+    write-dispatcher {
+      executor = "thread-pool-executor"
+      type = PinnedDispatcher
+    }
+
+    read-dispatcher {
+      type = Dispatcher
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-min = 2
+        parallelism-max = 16
       }
     }
   }

--- a/src/main/scala/com/rbmhtechnology/eventuate/DurableEvent.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/DurableEvent.scala
@@ -18,6 +18,8 @@ package com.rbmhtechnology.eventuate
 
 import DurableEvent._
 
+import scala.collection.immutable.Seq
+
 /**
  * Provider API.
  *
@@ -89,9 +91,37 @@ object DurableEvent {
   val UndefinedLogId = ""
   val UndefinedSequenceNr = 1L
 
+  /**
+   * Returns a process id for given `replicaId`.
+   */
   def processId(replicaId: String): String =
     processId(replicaId, None)
 
+  /**
+   * Returns a process id for given `replicaId` and optional `aggregateId`.
+   */
   def processId(replicaId: String, aggregateId: Option[String]): String =
     aggregateId.map(id => s"${replicaId}-${id}").getOrElse(replicaId)
+}
+
+/**
+ * Event batch storage format.
+ *
+ * @param events Event batch.
+ * @param sourceLogId Source log id if the batch was read from a source log (= replicated).
+ * @param lastSourceLogSequenceNrRead Last source log sequence number read after reading this batch from the source log.
+ */
+case class DurableEventBatch(events: Seq[DurableEvent], sourceLogId: Option[String] = None, lastSourceLogSequenceNrRead: Option[Long] = None) {
+
+  /**
+   * `true` if this batch was replicated.
+   */
+  def replicated: Boolean =
+    sourceLogId.isDefined
+
+  /**
+   * Highest event sequence number contained in the event batch.
+   */
+  def highestSequenceNr: Option[Long] =
+    events.lastOption.map(_.sequenceNr)
 }

--- a/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
@@ -22,19 +22,6 @@ import scala.collection.immutable.Seq
 
 object EventsourcingProtocol {
   /**
-   * Instructs an event log to loop the given `commands` to the given `requestor`, preserving
-   * the relative order to events being written by that event log. Commands are looped to the
-   * `requestor` one-by-one within a [[DelayComplete]] message with `commandSender` as the
-   * message sender.
-   */
-  case class Delay(commands: Seq[Any], commandsSender: ActorRef, requestor: ActorRef, instanceId: Int)
-
-  /**
-   * Completion reply after a [[Delay]].
-   */
-  case class DelayComplete(command: Any, instanceId: Int)
-
-  /**
    * Instructs an event log to batch-execute the given `writes`.
    */
   case class WriteN(writes: Seq[Write])

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/BatchingEventLog.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/BatchingEventLog.scala
@@ -61,10 +61,6 @@ class BatchingEventLog(eventLogProps: Props) extends Actor {
       writeAll() // ensures that Replay commands are properly ordered relative to Write commands
       eventLog forward r
       context.become(idle)
-    case d: Delay =>
-      writeAll() // ensures that Delay commands are properly ordered relative to Write commands
-      eventLog forward d
-      context.become(idle)
     case cmd =>
       eventLog forward cmd
   }

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.nio.ByteBuffer
+
+import akka.actor._
+import akka.event.{LogSource, Logging}
+import akka.serialization.SerializationExtension
+
+import com.datastax.driver.core._
+import com.datastax.driver.core.utils.Bytes
+
+import com.rbmhtechnology.eventuate.DurableEventBatch
+
+import scala.concurrent.duration._
+import scala.util._
+
+object Cassandra extends ExtensionId[Cassandra] with ExtensionIdProvider {
+  implicit val logSource: LogSource[AnyRef] = new LogSource[AnyRef] {
+    override def genString(o: AnyRef): String =
+      o.getClass.getName
+
+    override def getClazz(o: AnyRef): Class[_] =
+      o.getClass
+  }
+
+  def createExtension(system: ExtendedActorSystem): Cassandra =
+    new Cassandra(system)
+
+  def lookup() =
+    Cassandra
+}
+
+/**
+ * An Akka extension for using [[http://cassandra.apache.org/ Apache Cassandra]] as event log storage backend.
+ * The extension connects to the configured Cassandra cluster and creates the configured keyspace if it doesn't
+ * exist yet. Keyspace auto-creation can be turned off by setting
+ *
+ * {{{
+ *   eventuate.log.cassandra.keyspace-autocreate = false
+ * }}}
+ *
+ * The name of the keyspace defaults to `eventuate` and can be configured with
+ *
+ * {{{
+ *   eventuate.log.cassandra.keyspace = "eventuate"
+ * }}}
+ *
+ * The Cassandra cluster contact points can be configured with
+ *
+ * {{{
+ *   eventuate.log.cassandra.contact-points = [host1[:port1], host2[:port2], ...]
+ * }}}
+ *
+ * Ports are optional and default to `9042` according to
+ *
+ * {{{
+ *   eventuate.log.cassandra.default-port = 9042
+ * }}}
+ *
+ * This extension also creates two index tables for storing replication progress data and event log indexing
+ * progress data. The names of these tables have a prefix defined by
+ *
+ * {{{
+ *   eventuate.log.cassandra.table-prefix = "log"
+ * }}}
+ *
+ * Assuming a `log` prefix
+ *
+ *  - the replication progress table name is `log_rp` and
+ *  - the log indexing progress table name is `log_snr`.
+ *
+ * If two instances of this extensions are created concurrently by two different actor systems, index table
+ * creation can fail (see [[https://issues.apache.org/jira/browse/CASSANDRA-8387 CASSANDRA-8387]]). It is
+ * therefore recommended to initialize a clean Cassandra cluster with a separate administrative application
+ * that only creates an instance of this Akka extension before creating [[CassandraEventLog]] actors. This
+ * must be done only once. Alternatively, different actor systems can be configured with different
+ * `eventuate.log.cassandra.keyspace` names. In this case they won't share a keyspace and index tables and
+ * concurrent initialization is not an issue.
+ *
+ * @see [[CassandraEventLog]]
+ */
+class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =>
+
+  /**
+   * Configuration used by the Cassandra storage backend. Closed when the `ActorSystem` of
+   * this extension terminates.
+   */
+  private[eventuate] val config = new CassandraConfig(system.settings.config.getConfig("eventuate.log.cassandra"))
+
+  /**
+   * Serializer used by the Cassandra storage backend. Closed when the `ActorSystem` of
+   * this extension terminates.
+   */
+  private[eventuate] val serializer = SerializationExtension(system)
+
+  private val logging = Logging(system, this)
+  private val statements = new CassandraEventStatements
+    with CassandraAggregateEventStatements
+    with CassandraSequenceNumberStatements
+    with CassandraReplicationProgressStatements {
+
+    override def config: CassandraConfig =
+      extension.config
+  }
+
+  import config._
+  import statements._
+
+  private var _cluster: Cluster = _
+  private var _session: Session = _
+
+  Try {
+    _cluster = clusterBuilder.build
+    _session = _cluster.connect()
+
+    if (config.keyspaceAutoCreate)
+      session.execute(createKeySpaceStatement)
+
+    _session.execute(createSequenceNumberTableStatement)
+    _session.execute(createReplicationProgressTableStatement)
+  } match {
+    case Success(_) => logging.info("Cassandra extension initialized")
+    case Failure(e) => logging.error(e, "Cassandra extension initialization failed."); exit() // TODO: retry
+  }
+
+  /**
+   * Cassandra cluster reference.
+   */
+  def cluster: Cluster =
+    _cluster
+
+  /**
+   * Cassandra session used by this extension.
+   */
+  def session: Session =
+    _session
+
+  /**
+   * Dispatcher for event log and index reads.
+   */
+  private[eventuate] implicit val readDispatcher =
+    system.dispatchers.lookup("eventuate.log.cassandra.read-dispatcher")
+
+  private[eventuate] def createEventTable(logId: String): Unit =
+    session.execute(createEventTableStatement(logId))
+
+  private[eventuate] def createAggregateEventTable(logId: String): Unit =
+    session.execute(createAggregateEventTableStatement(logId))
+
+  private[eventuate] def prepareWriteEventBatch(logId: String): PreparedStatement =
+    session.prepare(writeEventBatchStatement(logId)).setConsistencyLevel(config.writeConsistency)
+
+  private[eventuate] def prepareReadEventBatches(logId: String): PreparedStatement =
+    session.prepare(readEventBatchesStatement(logId)).setConsistencyLevel(config.readConsistency)
+
+  private[eventuate] def prepareWriteAggregateEventBatch(logId: String): PreparedStatement =
+    session.prepare(writeAggregateEventBatchStatement(logId)).setConsistencyLevel(config.writeConsistency)
+
+  private[eventuate] def prepareReadAggregateEventBatches(logId: String): PreparedStatement =
+    session.prepare(readAggregateEventBatchesStatement(logId)).setConsistencyLevel(config.readConsistency)
+
+  private[eventuate] val preparedWriteSequenceNumberStatement: PreparedStatement =
+    session.prepare(writeSequenceNumberStatement).setConsistencyLevel(config.writeConsistency)
+
+  private[eventuate] val preparedReadSequenceNumberStatement: PreparedStatement =
+    session.prepare(readSequenceNumberStatement).setConsistencyLevel(config.readConsistency)
+
+  private[eventuate] val preparedWriteReplicationProgressStatement: PreparedStatement =
+    session.prepare(writeReplicationProgressStatement).setConsistencyLevel(config.writeConsistency)
+
+  private[eventuate] val preparedReadReplicationProgressStatement: PreparedStatement =
+    session.prepare(readReplicationProgressStatement).setConsistencyLevel(config.readConsistency)
+
+  private[eventuate] def eventBatchToByteBuffer(b: DurableEventBatch): ByteBuffer =
+    ByteBuffer.wrap(serializer.serialize(b).get)
+
+  private[eventuate] def eventBatchFromByteBuffer(b: ByteBuffer): DurableEventBatch =
+    serializer.deserialize(Bytes.getArray(b), classOf[DurableEventBatch]).get
+
+  private def exit(): Unit =
+    system.shutdown()
+
+  system.registerOnTermination {
+    session.close()
+    cluster.close()
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraConfig.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraConfig.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+import com.datastax.driver.core.{Cluster, ConsistencyLevel}
+import com.typesafe.config.Config
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+private[eventuate] class CassandraConfig(config: Config) {
+  import CassandraConfig._
+
+  val keyspace: String =
+    config.getString("keyspace")
+
+  val keyspaceAutoCreate: Boolean =
+    config.getBoolean("keyspace-autocreate")
+
+  val replicationFactor: Int =
+    config.getInt("replication-factor")
+
+  val tablePrefix: String =
+    config.getString("table-prefix")
+
+  val readConsistency: ConsistencyLevel =
+    ConsistencyLevel.valueOf(config.getString("read-consistency"))
+
+  val writeConsistency: ConsistencyLevel =
+    ConsistencyLevel.valueOf(config.getString("write-consistency"))
+
+  val defaultPort: Int =
+    config.getInt("default-port")
+
+  val contactPoints =
+    getContactPoints(config.getStringList("contact-points").asScala, defaultPort)
+
+  val maxResultSetSize: Int =
+    config.getInt("max-result-set-size")
+
+  val initRetryBackoff: FiniteDuration =
+    config.getDuration("init-retry-backoff", TimeUnit.MILLISECONDS).millis
+
+  val indexUpdateLimit: Int =
+    config.getInt("index-update-limit")
+
+  val clusterBuilder: Cluster.Builder =
+    Cluster.builder.addContactPointsWithPorts(contactPoints.asJava)
+
+  if (config.hasPath("authentication")) {
+    clusterBuilder.withCredentials(
+      config.getString("authentication.username"),
+      config.getString("authentication.password"))
+  }
+}
+
+private object CassandraConfig {
+  def getContactPoints(contactPoints: Seq[String], defaultPort: Int): Seq[InetSocketAddress] = {
+    contactPoints match {
+      case null | Nil => throw new IllegalArgumentException("a contact point list cannot be empty.")
+      case hosts => hosts map {
+        ipWithPort => ipWithPort.split(":") match {
+          case Array(host, port) => new InetSocketAddress(host, port.toInt)
+          case Array(host) => new InetSocketAddress(host, defaultPort)
+          case msg => throw new IllegalArgumentException(s"a contact point should have the form [host:port] or [host] but was: $msg.")
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.lang.{Long => JLong}
+
+import akka.actor._
+
+import com.rbmhtechnology.eventuate._
+import com.rbmhtechnology.eventuate.EventsourcingProtocol._
+import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.rbmhtechnology.eventuate.log.{BatchingEventLog, AggregateRegistry}
+
+import scala.collection.immutable.Seq
+import scala.language.implicitConversions
+import scala.util._
+
+/**
+ * An event log actor with [[http://cassandra.apache.org/ Apache Cassandra]] as storage backend. It uses
+ * the [[Cassandra]] extension to connect to a Cassandra cluster. Applications should create an instance
+ * of this actor using the `props` method of the `CassandraEventLog` [[CassandraEventLog$ companion object]].
+ *
+ * {{{
+ *   val factory: ActorRefFactory = ... // ActorSystem or ActorContext
+ *   val logId: String = "example"      // Unique log id
+ *
+ *   val log = factory.actorOf(CassandraEventLog.props(logId))
+ * }}}
+ *
+ * Each event log actor creates two tables in the configured keyspace (see also [[Cassandra]]). Assuming
+ * the following table prefix
+ *
+ * {{{
+ *   eventuate.log.cassandra.table-prefix = "log"
+ * }}}
+ *
+ * and a log `id` with value `example`, the names of these two tables are
+ *
+ *  - `log_example` which represents the local event log.
+ *  - `log_example_agg` which is an index of the local event log for those events that have non-empty
+ *    [[DurableEvent#routingDestinations routingDestinations]] set. It is used for fast recovery of
+ *    event-sourced actors or views that have an [[Eventsourced#aggregateId aggregateId]] defined.
+ *
+ * @param id unique log id.
+ *
+ * @see [[Cassandra]]
+ * @see [[DurableEvent]]
+ */
+class CassandraEventLog(id: String) extends Actor with Stash {
+  import CassandraEventLog._
+
+  private val eventStream = context.system.eventStream
+  private val cassandra: Cassandra = Cassandra(context.system)
+
+  cassandra.createEventTable(id)
+  cassandra.createAggregateEventTable(id)
+
+  private val statement = cassandra.prepareWriteEventBatch(id)
+
+  private val reader = createReader(cassandra, id)
+  private val index = createIndex(cassandra, reader, id)
+
+  private var sequenceNrUpdates: Long = 0L
+  private var sequenceNr: Long = 0L
+
+  private var defaultRegistry: Set[ActorRef] = Set.empty
+  private var aggregateRegistry: AggregateRegistry = AggregateRegistry()
+
+  def initializing: Receive = {
+    case Initialize(snr) =>
+      sequenceNr = snr
+      unstashAll()
+      context.become(initialized)
+    case other =>
+      stash()
+  }
+
+  def initialized: Receive = {
+    case cmd: GetLastSourceLogReadPosition =>
+      index.forward(cmd)
+    case cmd @ Replay(_, requestor, Some(emitterAggregateId), _) =>
+      aggregateRegistry = aggregateRegistry.add(context.watch(requestor), emitterAggregateId)
+      index.forward(cmd)
+    case Replay(from, requestor, None, iid) =>
+      defaultRegistry = defaultRegistry + context.watch(requestor)
+
+      import cassandra.readDispatcher
+      reader.replayAsync(from)(event => requestor ! Replaying(event, iid) ) onComplete {
+        case Success(_) => requestor ! ReplaySuccess(iid)
+        case Failure(e) => requestor ! ReplayFailure(e, iid)
+      }
+    case r @ ReplicationRead(from, max, filter, targetLogId) =>
+      val sdr = sender()
+      eventStream.publish(r)
+
+      import cassandra.readDispatcher
+      reader.readAsync(from, max, filter, targetLogId) onComplete {
+        case Success(result) =>
+          val r = ReplicationReadSuccess(result.events, result.to, targetLogId)
+          sdr ! r
+          eventStream.publish(r)
+        case Failure(cause)  =>
+          val r = ReplicationReadFailure(cause.getMessage, targetLogId)
+          sdr ! r
+          eventStream.publish(r)
+      }
+    case Write(events, eventsSender, requestor, iid) =>
+      val updated = prepareWrite(events)
+
+      Try(write(DurableEventBatch(updated))) match {
+        case Success(_) =>
+          pushWriteSuccess(updated, eventsSender, requestor, iid)
+          publishUpdateNotification(updated)
+          requestIndexUpdate()
+        case Failure(e) =>
+          pushWriteFailure(updated, eventsSender, requestor, iid, e)
+      }
+    case WriteN(writes) =>
+      val updatedWrites = writes.map(w => w.copy(prepareWrite(w.events)))
+      val updatedEvents = updatedWrites.map(_.events).flatten
+
+      Try(write(DurableEventBatch(updatedEvents))) match {
+        case Success(_) =>
+          updatedWrites.foreach(w => pushWriteSuccess(w.events, w.eventsSender, w.requestor, w.instanceId))
+          publishUpdateNotification(updatedEvents)
+          requestIndexUpdate()
+        case Failure(e) =>
+          updatedWrites.foreach(w => pushWriteFailure(w.events, w.eventsSender, w.requestor, w.instanceId, e))
+      }
+      sender() ! WriteNComplete // notify batch layer that write completed
+    case r @ ReplicationWrite(Seq(), _, _) =>
+      index.forward(r)
+    case ReplicationWrite(events, sourceLogId, lastSourceLogSequenceNrRead) =>
+      val snr = sequenceNr
+      val updated = prepareReplicate(events)
+
+      Try(write(DurableEventBatch(updated, Some(sourceLogId), Some(lastSourceLogSequenceNrRead)))) match {
+        case Success(_) =>
+          sender() ! ReplicationWriteSuccess(events.size, lastSourceLogSequenceNrRead)
+          pushReplicateSuccess(updated)
+          publishUpdateNotification(updated)
+          requestIndexUpdate()
+        case Failure(e) =>
+          sender() ! ReplicationWriteFailure(e)
+          sequenceNr = snr
+      }
+    case Terminated(requestor) =>
+      aggregateRegistry.aggregateId(requestor) match {
+        case Some(aggregateId) => aggregateRegistry = aggregateRegistry.remove(requestor, aggregateId)
+        case None              => defaultRegistry = defaultRegistry - requestor
+      }
+  }
+
+  override def receive =
+    initializing
+
+  private[eventuate] def createReader(cassandra: Cassandra, logId: String) =
+    new CassandraEventReader(cassandra, logId)
+
+  private[eventuate] def createIndex(cassandra: Cassandra, eventReader: CassandraEventReader, logId: String) =
+    context.actorOf(CassandraIndex.props(cassandra, eventReader, logId))
+
+  private[eventuate] def write(batch: DurableEventBatch): Unit =
+    cassandra.session.execute(statement.bind(0L: JLong, sequenceNr: JLong, cassandra.eventBatchToByteBuffer(batch)))
+
+  // ---------------------------------------------------------------------------
+  //  Notifications for writers, subscribers, listeners and index
+  // ---------------------------------------------------------------------------
+
+  private def requestIndexUpdate(): Unit = {
+    if (sequenceNrUpdates >= cassandra.config.indexUpdateLimit) {
+      index ! CassandraIndex.UpdateIndex()
+      sequenceNrUpdates = 0L
+    }
+  }
+
+  private def publishUpdateNotification(events: Seq[DurableEvent] = Seq()): Unit =
+    if (events.nonEmpty) eventStream.publish(Updated(id, events))
+
+  private def pushReplicateSuccess(events: Seq[DurableEvent]): Unit = {
+    events.foreach { event =>
+      // in any case, notify all default subscribers
+      defaultRegistry.foreach(_ ! Written(event))
+      // notify subscribers with matching aggregate id
+      for {
+        aggregateId <- event.routingDestinations
+        aggregate <- aggregateRegistry(aggregateId)
+      } aggregate ! Written(event)
+    }
+  }
+
+  private def pushWriteSuccess(events: Seq[DurableEvent], eventsSender: ActorRef, requestor: ActorRef, instanceId: Int): Unit =
+    events.foreach { event =>
+      requestor.tell(WriteSuccess(event, instanceId), eventsSender)
+      // in any case, notify all default subscribers (except requestor)
+      defaultRegistry.foreach(r => if (r != requestor) r ! Written(event))
+      // notify subscribers with matching aggregate id (except requestor)
+      for {
+        aggregateId <- event.routingDestinations
+        aggregate <- aggregateRegistry(aggregateId) if aggregate != requestor
+      } aggregate ! Written(event)
+    }
+
+  private def pushWriteFailure(events: Seq[DurableEvent], eventsSender: ActorRef, requestor: ActorRef, instanceId: Int, cause: Throwable): Unit =
+    events.foreach { event =>
+      requestor.tell(WriteFailure(event, cause, instanceId), eventsSender)
+    }
+
+  // ---------------------------------------------------------------------------
+  //  ...
+  // ---------------------------------------------------------------------------
+
+  private def prepareWrite(events: Seq[DurableEvent]): Seq[DurableEvent] =
+    events.map { event =>
+      val snr = nextSequenceNr()
+      event.copy(
+        sourceLogId = id,
+        targetLogId = id,
+        sourceLogSequenceNr = snr,
+        targetLogSequenceNr = snr)
+    }
+
+  private def prepareReplicate(events: Seq[DurableEvent]): Seq[DurableEvent] =
+    events.map { event =>
+      val snr = nextSequenceNr()
+      event.copy(
+        sourceLogId = event.targetLogId,
+        targetLogId = id,
+        sourceLogSequenceNr = event.targetLogSequenceNr,
+        targetLogSequenceNr = snr)
+    }
+
+  private def nextSequenceNr(): Long = {
+    sequenceNr += 1L
+    sequenceNrUpdates += 1
+    sequenceNr
+  }
+
+  private[eventuate] def currentSequenceNr: Long =
+    sequenceNr
+}
+
+object CassandraEventLog {
+  private[eventuate] case class Initialize(sequenceNr: Long)
+
+  /**
+   * Creates a [[CassandraEventLog]] configuration object.
+   *
+   * @param logId unique log id.
+   * @param batching `true` if write-batching shall be enabled (recommended).
+   */
+  def props(logId: String, batching: Boolean = true): Props = {
+    val logProps = Props(new CassandraEventLog(logId)).withDispatcher("eventuate.log.cassandra.write-dispatcher")
+    if (batching) Props(new BatchingEventLog(logProps)) else logProps
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventReader.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventReader.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.lang.{Long => JLong}
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BinaryOperator
+
+import com.datastax.driver.core.{PreparedStatement, Row}
+import com.rbmhtechnology.eventuate._
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.{VectorBuilder, Seq}
+import scala.concurrent.Future
+
+private[eventuate] class CassandraEventReader(cassandra: Cassandra, logId: String) extends CassandraEventIteratorLeasing {
+  import CassandraEventReader._
+
+  val statement: PreparedStatement =
+    cassandra.prepareReadEventBatches(logId)
+
+  def replayAsync(fromSequenceNr: Long)(f: DurableEvent => Unit): Future[Unit] =
+    Future(replay(fromSequenceNr)(f))(cassandra.readDispatcher)
+
+  def replay(fromSequenceNr: Long)(f: DurableEvent => Unit): Unit =
+    eventIterator(fromSequenceNr, Long.MaxValue).foreach(f)
+
+  def readAsync(fromSequenceNr: Long, max: Int, filter: ReplicationFilter, targetLogId: String): Future[ReadResult] = {
+    Future(read(fromSequenceNr, max, filter, targetLogId))(cassandra.readDispatcher)
+  }
+
+  def read(fromSequenceNr: Long, max: Int, filter: ReplicationFilter, targetLogId: String): ReadResult = {
+    val builder = new VectorBuilder[DurableEvent]
+    val iterator = leaseEventIterator(targetLogId, fromSequenceNr)
+    var num = 0
+
+    while (iterator.hasNext && num < max) {
+      val event = iterator.next()
+      if (filter.apply(event)) {
+        builder += event
+        num += 1
+      }
+    }
+    releaseEventIterator(iterator)
+    ReadResult(builder.result(), iterator.lastSequenceNrRead)
+  }
+
+  def eventIterator(fromSequenceNr: Long, toSequenceNr: Long): Iterator[DurableEvent] = for {
+    batch <- eventBatchIterator(fromSequenceNr, toSequenceNr)
+    event <- batch.events if event.sequenceNr >= fromSequenceNr && event.sequenceNr <= toSequenceNr
+  } yield event
+
+  def eventBatchIterator(fromSequenceNr: Long, toSequenceNr: Long): Iterator[DurableEventBatch] =
+    new EventBatchIterator(fromSequenceNr, toSequenceNr)
+
+  private class EventBatchIterator(fromSequenceNr: Long, toSequenceNr: Long) extends Iterator[DurableEventBatch] {
+    var currentSnr = fromSequenceNr
+    var currentIter = newIter()
+    var rowCount = 0
+
+    def newIter(): Iterator[Row] =
+      if (currentSnr > toSequenceNr) Iterator.empty else cassandra.session.execute(statement.bind(0L: JLong, currentSnr: JLong)).iterator.asScala
+
+    @annotation.tailrec
+    final def hasNext: Boolean = {
+      if (currentIter.hasNext) {
+        true
+      } else if (rowCount < cassandra.config.maxResultSetSize) {
+        // all batches consumed
+        false
+      } else {
+        // max result set size reached, fetch again
+        currentSnr += 1L
+        currentIter = newIter()
+        rowCount = 0
+        hasNext
+      }
+    }
+
+    def next(): DurableEventBatch = {
+      val row = currentIter.next()
+      currentSnr = row.getLong("sequence_nr")
+      rowCount += 1
+      cassandra.eventBatchFromByteBuffer(row.getBytes("eventBatch"))
+    }
+  }
+}
+
+private[eventuate] object CassandraEventReader {
+  case class ReadResult(events: Seq[DurableEvent], to: Long)
+}
+
+private[eventuate] trait CassandraEventIteratorLeasing {
+  import CassandraEventIteratorLeasing._
+
+  private val eventLogIterators: AtomicReference[Map[String, LeasableEventIterator]] =
+    new AtomicReference(Map.empty)
+
+  def eventIterator(fromSequenceNr: Long, toSequenceNr: Long): Iterator[DurableEvent]
+
+  def leaseEventIterator(leaserId: String, fromSequenceNr: Long): LeasableEventIterator = {
+    eventLogIterators.get.get(leaserId) match {
+      case Some(iter) if iter.lastSequenceNrRead == (fromSequenceNr - 1L) && iter.hasNext =>
+        iter
+      case _ =>
+        new LeasableEventIterator(leaserId, fromSequenceNr, eventIterator(fromSequenceNr, Long.MaxValue))
+    }
+  }
+
+  def releaseEventIterator(iterator: LeasableEventIterator): Unit = {
+    eventLogIterators.getAndAccumulate(Map(iterator.leaserId -> iterator), new BinaryOperator[Map[String, LeasableEventIterator]] {
+      override def apply(t: Map[String, LeasableEventIterator], u: Map[String, LeasableEventIterator]): Map[String, LeasableEventIterator] = t ++ u
+    })
+  }
+}
+
+private[eventuate] object CassandraEventIteratorLeasing {
+  class LeasableEventIterator(val leaserId: String, fromSequenceNr: Long, iterator: Iterator[DurableEvent]) extends Iterator[DurableEvent] {
+    private var _lastSequenceNrRead = fromSequenceNr - 1L
+
+    def lastSequenceNrRead: Long =
+      _lastSequenceNrRead
+
+    override def hasNext: Boolean =
+      iterator.hasNext
+
+    override def next(): DurableEvent = {
+      val event = iterator.next()
+      _lastSequenceNrRead = event.sequenceNr
+      event
+    }
+  }
+} 

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndex.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndex.scala
@@ -1,0 +1,382 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.lang.{Long => JLong}
+
+import akka.actor._
+import akka.pattern.pipe
+
+import com.datastax.driver.core.{Row, PreparedStatement}
+import com.rbmhtechnology.eventuate.{DurableEvent, DurableEventBatch}
+import com.rbmhtechnology.eventuate.EventsourcingProtocol._
+import com.rbmhtechnology.eventuate.ReplicationProtocol._
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+import scala.concurrent._
+import scala.util._
+
+private[eventuate] class CassandraIndex(cassandra: Cassandra, eventReader: CassandraEventReader, logId: String) extends Actor with Stash with ActorLogging {
+  import CassandraIndex._
+  import CassandraEventLog._
+  import context.dispatcher
+
+  private val scheduler = context.system.scheduler
+  private val eventLog = context.parent
+
+  private val indexStore = createIndexStore(cassandra, logId)
+  private val indexUpdater = context.actorOf(Props(new CassandraIndexUpdater(cassandra, eventReader, indexStore)))
+
+  /**
+   * Last sequence number in event log that has been successfully
+   * processed and written to index.
+   */
+  private var lastIndexedSequenceNr: Long = 0L
+
+  /**
+   * This is an optimization which prevents redundant empty reads
+   * from source logs in failure cases.
+   */
+  private var bufferedReplicationProgress = ReplicationProgress()
+
+  def initializing: Receive = {
+    case ReadSequenceNr =>
+      indexStore.readSequenceNumberAsync onComplete {
+        case Success(snr) => self ! ReadSequenceNrSuccess(snr)
+        case Failure(e)   => self ! ReadSequenceNrFailure(e)
+      }
+    case ReadSequenceNrSuccess(snr) =>
+      indexUpdater ! UpdateIndex(snr)
+    case u @ UpdateIndexSuccess(snr, numWrites) =>
+      this.lastIndexedSequenceNr = snr
+      eventLog ! Initialize(snr)
+      context.become(initialized)
+      unstashAll()
+      onIndexEvent(u)
+    case u @ UpdateIndexFailure(cause) =>
+      log.error(cause, "UpdateIndex failure")
+      scheduleReadSequenceNr()
+      onIndexEvent(u)
+    case r @ ReadSequenceNrFailure(cause) =>
+      log.error(cause, "ReadSequenceNr failed")
+      scheduleReadSequenceNr()
+      onIndexEvent(r)
+    case other =>
+      stash()
+  }
+
+  def initialized: Receive = {
+    case UpdateIndex(_, _) =>
+      indexUpdater ! UpdateIndex(lastIndexedSequenceNr, bufferedReplicationProgress)
+      bufferedReplicationProgress = ReplicationProgress()
+    case u @ UpdateIndexSuccess(snr, numWrites) =>
+      this.lastIndexedSequenceNr = snr
+      onIndexEvent(u)
+    case u @ UpdateIndexFailure(cause) =>
+      log.error(cause, "UpdateIndex failure")
+      onIndexEvent(u)
+    case w @ ReplicationWrite(Seq(), sourceLogId, lastSourceLogSequenceNrRead) =>
+      bufferedReplicationProgress = bufferedReplicationProgress.update(sourceLogId, lastSourceLogSequenceNrRead)
+      sender() ! ReplicationWriteSuccess(0, lastSourceLogSequenceNrRead)
+    case r @ Replay(fromSequenceNr, requestor, Some(emitterAggregateId), iid) =>
+      val isnr = lastIndexedSequenceNr
+      val replay = for {
+        rsnr <- indexStore.replayAsync(emitterAggregateId, fromSequenceNr)(event =>requestor ! Replaying(event, iid))
+        nsnr = math.max(isnr, rsnr) + 1L
+        s    <- eventReader.replayAsync(nsnr)(event => if (event.routingDestinations.contains(emitterAggregateId))requestor ! Replaying(event, iid))
+      } yield s
+
+      replay onComplete {
+        case Success(_) => requestor ! ReplaySuccess(iid)
+        case Failure(e) => requestor ! ReplayFailure(e, iid)
+      }
+    case GetLastSourceLogReadPosition(sourceLogId) =>
+      val inc = IndexIncrement(lastIndexedSequenceNr, bufferedReplicationProgress)
+      val sdr = sender()
+
+      val ftr = for {
+        prg <- indexStore.readReplicationProgressAsync
+        res <- updateIncrementAsync(inc.update(prg))
+      } yield res.replicationProgress(sourceLogId)
+
+      ftr onComplete {
+        case Success(snr) => sdr ! GetLastSourceLogReadPositionSuccess(sourceLogId, snr)
+        case Failure(err) => sdr ! GetLastSourceLogReadPositionFailure(err); log.error(err, "GetLastSourceLogReadPosition failure")
+      }
+  }
+
+  def receive =
+    initializing
+
+  private[eventuate] def createIndexStore(cassandra: Cassandra, logId: String) =
+    new CassandraIndexStore(cassandra, logId)
+
+  private def scheduleReadSequenceNr(): Unit =
+    scheduler.scheduleOnce(cassandra.config.initRetryBackoff, self, ReadSequenceNr)
+
+  private def updateIncrementAsync(increment: IndexIncrement): Future[IndexIncrement] =
+    Future(updateIncrement(increment))(cassandra.readDispatcher)
+  
+  private def updateIncrement(increment: IndexIncrement): IndexIncrement = {
+    eventReader.eventBatchIterator(increment.sequenceNr + 1L, Long.MaxValue).foldLeft(increment) {
+      case (inc, batch) => inc.update(batch)
+    }
+  }
+
+  override def preStart(): Unit =
+    self ! ReadSequenceNr
+
+  // ------------------------------------------------------------------
+  //  Test support
+  // ------------------------------------------------------------------
+
+  def onIndexEvent(event: Any): Unit = ()
+}
+
+private[eventuate] object CassandraIndex {
+  case object ReadSequenceNr
+  case class ReadSequenceNrSuccess(lastIndexedSequenceNr: Long)
+  case class ReadSequenceNrFailure(cause: Throwable)
+
+  case class UpdateIndex(lastIndexedSequenceNr: Long = 0L, bufferedReplicationProgress: ReplicationProgress = ReplicationProgress())
+  case class UpdateIndexSuccess(lastIndexedSequenceNr: Long, numWrites: Int)
+  case class UpdateIndexFailure(cause: Throwable)
+
+  case class ReplicationProgress(lastSourceLogSequenceNrs: Map[String, Long] = Map.empty) {
+    def apply(sourceLogId: String): Long =
+      lastSourceLogSequenceNrs.getOrElse(sourceLogId, 0L)
+
+    def update(progress: ReplicationProgress): ReplicationProgress =
+      progress.lastSourceLogSequenceNrs.foldLeft(this) {
+        case (progress, (sourceLogId, lastSourceSequenceNrRead)) => progress.update(sourceLogId, lastSourceSequenceNrRead)
+      }
+
+    def update(sourceLogId: String, lastSourceLogSequenceNrRead: Long): ReplicationProgress =
+      lastSourceLogSequenceNrs.get(sourceLogId) match {
+        case Some(lastSourceLogSequenceNrStored) if lastSourceLogSequenceNrRead < lastSourceLogSequenceNrStored => this
+        case _ => copy(lastSourceLogSequenceNrs + (sourceLogId -> lastSourceLogSequenceNrRead))
+      }
+  }
+
+  case class IndexUpdateProgress(increment: IndexIncrement, pendingEvents: Int = 0, writes: Vector[Future[Long]] = Vector.empty) {
+    def update(batch: DurableEventBatch): IndexUpdateProgress =
+      copy(increment.update(batch), pendingEvents + batch.events.size)
+
+    def writeIncrement(writer: IndexIncrement => Future[Long]): IndexUpdateProgress =
+      copy(IndexIncrement(increment.sequenceNr), 0, writes = writes :+ writer(increment))
+  }
+
+  case class IndexIncrement(sequenceNr: Long, replicationProgress: ReplicationProgress = ReplicationProgress(), aggregateEvents: Map[String, Vector[DurableEvent]] = Map.empty) {
+    def update(progress: ReplicationProgress): IndexIncrement =
+      copy(replicationProgress = replicationProgress.update(progress))
+
+    def update(batch: DurableEventBatch): IndexIncrement = {
+      val events = addAggregateEvents(batch)
+      val hsnr = batch.highestSequenceNr.get
+
+      val updated = for {
+        slid <- batch.sourceLogId
+        rsnr <- batch.lastSourceLogSequenceNrRead
+      } yield copy(hsnr, replicationProgress.update(slid, rsnr), events)
+
+      updated.getOrElse(copy(hsnr, aggregateEvents = events))
+    }
+
+    private def addAggregateEvents(batch: DurableEventBatch): Map[String, Vector[DurableEvent]] =
+      batch.events.foldLeft(aggregateEvents)(addAggregateEvent)
+
+    private def addAggregateEvent(aggregateEvents: Map[String, Vector[DurableEvent]], event: DurableEvent): Map[String, Vector[DurableEvent]] =
+      event.routingDestinations.foldLeft(aggregateEvents) {
+        case (acc, dst) => acc.get(dst) match {
+          case Some(events) => acc + (dst -> (events :+ event))
+          case None         => acc + (dst -> Vector(event))
+        }
+      }
+  }
+
+  def props(cassandra: Cassandra, eventReader: CassandraEventReader, logId: String): Props =
+    Props(new CassandraIndex(cassandra, eventReader, logId: String))
+}
+
+private[eventuate] class CassandraIndexUpdater(cassandra: Cassandra, eventReader: CassandraEventReader, indexStore: CassandraIndexStore) extends Actor {
+  import CassandraIndex._
+  import context.dispatcher
+
+  val index = context.parent
+
+  val idle: Receive = {
+    case UpdateIndex(lastIndexedSequenceNr, bufferedReplicationProgress) =>
+      runIndexUpdate(lastIndexedSequenceNr, bufferedReplicationProgress)
+      context.become(updating)
+  }
+
+  val updating: Receive = {
+    case r: UpdateIndexSuccess =>
+      index ! r
+      context.become(idle)
+    case r: UpdateIndexFailure =>
+      index ! r
+      context.become(idle)
+    case UpdateIndex =>
+      // ignore
+  }
+
+  def receive = idle
+
+  private def runIndexUpdate(lastIndexedSequenceNr: Long, bufferedReplicationProgress: ReplicationProgress): Unit = {
+    val increment = IndexIncrement(lastIndexedSequenceNr, bufferedReplicationProgress)
+    val update: Future[(Long, Int)] = Future {
+      val initialProgress = eventReader.eventBatchIterator(increment.sequenceNr + 1L, Long.MaxValue).foldLeft(IndexUpdateProgress(increment)) {
+        case (progress, batch) =>
+          val updatedProgress = progress.update(batch)
+          if (updatedProgress.pendingEvents >= cassandra.config.indexUpdateLimit) {
+            // Enough data read from log. Write accumulated increment
+            // so that we don't consume too much memory and continue
+            // with an empty increment.
+            updatedProgress.writeIncrement(indexStore.writeIndexIncrementAsync)
+          } else updatedProgress
+      }
+
+      val finalProgress = if (initialProgress.pendingEvents > 0) {
+        // Some log entries have been processed since last write
+        // which must be finally written to the index.
+        initialProgress.writeIncrement(indexStore.writeIndexIncrementAsync)
+      } else initialProgress
+
+      Future.sequence(finalProgress.writes).map {
+        case Seq() => (finalProgress.increment.sequenceNr, 0)
+        case snrs  => (snrs.max, snrs.size)
+      }
+    }.flatMap(identity)(cassandra.readDispatcher)
+
+    update map {
+      case (snr, numWrites) => UpdateIndexSuccess(snr, numWrites)
+    } recover {
+      case t => UpdateIndexFailure(t)
+    } pipeTo self
+  }
+}
+
+private[eventuate] class CassandraIndexStore(cassandra: Cassandra, logId: String) {
+  import CassandraIndex._
+
+  private val aggregateEventWriteStatement: PreparedStatement = cassandra.prepareWriteAggregateEventBatch(logId)
+  private val aggregateEventReadStatement: PreparedStatement = cassandra.prepareReadAggregateEventBatches(logId)
+
+  def replayAsync(aggregateId: String, fromSequenceNr: Long)(f: DurableEvent => Unit): Future[Long] = {
+    import cassandra.readDispatcher
+    Future(replay(aggregateId, fromSequenceNr)(f))
+  }
+
+  def replay(aggregateId: String, fromSequenceNr: Long)(f: DurableEvent => Unit): Long = {
+    var highWatermark = fromSequenceNr - 1L
+    aggregateEventIterator(aggregateId, fromSequenceNr, Long.MaxValue).foreach { event =>
+      if (event.sequenceNr > highWatermark) {
+        highWatermark = event.sequenceNr
+        f(event)
+      } else { /* this is a duplicate */ }
+    }
+    highWatermark
+  }
+
+  def readReplicationProgressAsync: Future[ReplicationProgress] = {
+    import cassandra.readDispatcher
+    cassandra.session.executeAsync(cassandra.preparedReadReplicationProgressStatement.bind(logId)).map { resultSet =>
+      resultSet.iterator().asScala.foldLeft(ReplicationProgress()) {
+        case (progress, row) => progress.update(row.getString("source_log_id"), row.getLong("source_log_read_pos"))
+      }
+    }
+  }
+
+  def readSequenceNumberAsync: Future[Long] = {
+    import cassandra.readDispatcher
+    cassandra.session.executeAsync(cassandra.preparedReadSequenceNumberStatement.bind(logId)).map { resultSet =>
+      if (resultSet.isExhausted) 0L else resultSet.one().getLong("sequence_nr")
+    }
+  }
+
+  def writeIndexIncrementAsync(increment: IndexIncrement)(implicit executor: ExecutionContext): Future[Long] = {
+    val f1 = writeAggregateEventsAsync(increment.aggregateEvents)
+    val f2 = writeReplicationProgressAsync(increment.replicationProgress)
+
+    for {
+      _   <- f1
+      _   <- f2
+      snr <- writeSequenceNrAsync(increment.sequenceNr)
+    } yield snr
+  }
+
+  private def writeAggregateEventsAsync(aggregateEvents: Map[String, Vector[DurableEvent]])(implicit executor: ExecutionContext): Future[Unit] =
+    Future.sequence(aggregateEvents.map {
+      case (aggregateId, events) => writeAggregateEventsAsync(aggregateId, DurableEventBatch(events))
+    }).map(_ => ())
+
+  private def writeAggregateEventsAsync(aggregateId: String, batch: DurableEventBatch)(implicit executor: ExecutionContext): Future[Unit] =
+    cassandra.session.executeAsync(aggregateEventWriteStatement.bind(aggregateId, batch.highestSequenceNr.get: JLong, cassandra.eventBatchToByteBuffer(batch))).map(_ => ())
+
+  private def writeReplicationProgressAsync(progress: ReplicationProgress)(implicit executor: ExecutionContext): Future[Unit] =
+    Future.sequence(progress.lastSourceLogSequenceNrs.map {
+      case (sourceLogId, lastRead) => writeReplicationProgressAsync(sourceLogId, lastRead)
+    }).map(_ => ())
+
+  private def writeReplicationProgressAsync(sourceLogId: String, lastSourceLogSequenceNrRead: Long)(implicit executor: ExecutionContext): Future[Unit] =
+    cassandra.session.executeAsync(cassandra.preparedWriteReplicationProgressStatement.bind(logId, sourceLogId, lastSourceLogSequenceNrRead: JLong)).map(_ => ())
+
+  private def writeSequenceNrAsync(sequenceNr: Long)(implicit executor: ExecutionContext): Future[Long] =
+    cassandra.session.executeAsync(cassandra.preparedWriteSequenceNumberStatement.bind(logId, sequenceNr: JLong)).map(_ => sequenceNr)
+
+  private def aggregateEventIterator(aggregateId: String, fromSequenceNr: Long, toSequenceNr: Long): Iterator[DurableEvent] = for {
+    batch <- aggregateEventBatchIterator(aggregateId, fromSequenceNr, toSequenceNr)
+    event <- batch.events if event.sequenceNr >= fromSequenceNr && event.sequenceNr <= toSequenceNr
+  } yield event
+
+  private def aggregateEventBatchIterator(aggregateId: String, fromSequenceNr: Long, toSequenceNr: Long): Iterator[DurableEventBatch] =
+    new AggregateEventBatchIterator(aggregateId, fromSequenceNr, toSequenceNr)
+
+  private class AggregateEventBatchIterator(aggregateId: String, fromSequenceNr: Long, toSequenceNr: Long) extends Iterator[DurableEventBatch] {
+    var currentSnr = fromSequenceNr
+    var currentIter = newIter()
+    var rowCount = 0
+
+    def newIter(): Iterator[Row] =
+      if (currentSnr > toSequenceNr) Iterator.empty else cassandra.session.execute(aggregateEventReadStatement.bind(aggregateId, currentSnr: JLong)).iterator.asScala
+
+    @annotation.tailrec
+    final def hasNext: Boolean = {
+      if (currentIter.hasNext) {
+        true
+      } else if (rowCount < cassandra.config.maxResultSetSize) {
+        // all batches consumed
+        false
+      } else {
+        // max result set size reached, fetch again
+        currentSnr += 1L
+        currentIter = newIter()
+        rowCount = 0
+        hasNext
+      }
+    }
+
+    def next(): DurableEventBatch = {
+      val row = currentIter.next()
+      currentSnr = row.getLong("sequence_nr")
+      rowCount += 1
+      cassandra.eventBatchFromByteBuffer(row.getBytes("eventBatch"))
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+private[eventuate] trait CassandraStatements {
+  def config: CassandraConfig
+
+  def createKeySpaceStatement = s"""
+      CREATE KEYSPACE IF NOT EXISTS ${config.keyspace}
+      WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : ${config.replicationFactor} }
+    """
+
+  def table(suffix: String): String =
+    s"${config.keyspace}.${config.tablePrefix}_${suffix}"
+}
+
+private[eventuate] trait CassandraEventStatements extends CassandraStatements {
+  def createEventTableStatement(logId: String) = s"""
+      CREATE TABLE IF NOT EXISTS ${eventTable(logId)} (
+        partition_nr bigint,
+        sequence_nr bigint,
+        marker text,
+        eventBatch blob,
+        PRIMARY KEY (partition_nr, sequence_nr, marker))
+        WITH COMPACT STORAGE
+    """
+
+  def writeEventHeaderStatement(logId: String) = s"""
+      INSERT INTO ${eventTable(logId)} (partition_nr, sequence_nr, marker, eventBatch)
+      VALUES (?, 0, 'H', 0x00)
+    """
+
+  def writeEventBatchStatement(logId: String) = s"""
+      INSERT INTO ${eventTable(logId)} (partition_nr, sequence_nr, marker, eventBatch)
+      VALUES (?, ?, 'E', ?)
+    """
+
+  def readEventHeaderStatement(logId: String) = s"""
+      SELECT * FROM ${eventTable(logId)} WHERE
+        partition_nr = ? AND
+        sequence_nr = 0
+    """
+
+  def readEventBatchesStatement(logId: String) = s"""
+      SELECT * FROM ${eventTable(logId)} WHERE
+        partition_nr = ? AND
+        sequence_nr >= ?
+      LIMIT ${config.maxResultSetSize}
+    """
+
+  def eventTable(logId: String) = table(logId)
+}
+
+private[eventuate] trait CassandraAggregateEventStatements extends CassandraStatements {
+  def createAggregateEventTableStatement(logId: String) = s"""
+      CREATE TABLE IF NOT EXISTS ${aggregateEventTable(logId)} (
+        aggregate_id text,
+        sequence_nr bigint,
+        eventBatch blob,
+        PRIMARY KEY (aggregate_id, sequence_nr))
+        WITH COMPACT STORAGE
+    """
+
+  def writeAggregateEventBatchStatement(logId: String) = s"""
+      INSERT INTO ${aggregateEventTable(logId)} (aggregate_id, sequence_nr, eventBatch)
+      VALUES (?, ?, ?)
+    """
+
+  def readAggregateEventBatchesStatement(logId: String) = s"""
+      SELECT * FROM ${aggregateEventTable(logId)} WHERE
+        aggregate_id = ? AND
+        sequence_nr >= ?
+      LIMIT ${config.maxResultSetSize}
+    """
+
+  def aggregateEventTable(logId: String) = s"${table(logId)}_agg"
+}
+
+private[eventuate] trait CassandraSequenceNumberStatements extends CassandraStatements {
+  def createSequenceNumberTableStatement = s"""
+      CREATE TABLE IF NOT EXISTS ${sequenceNumberTable} (
+        log_id text,
+        sequence_nr bigint,
+        PRIMARY KEY (log_id))
+    """
+
+  def writeSequenceNumberStatement = s"""
+      INSERT INTO ${sequenceNumberTable} (log_id, sequence_nr)
+      VALUES (?, ?)
+    """
+
+  def readSequenceNumberStatement = s"""
+      SELECT * FROM ${sequenceNumberTable} WHERE
+        log_id = ?
+    """
+
+  def sequenceNumberTable = table("snr")
+}
+
+private[eventuate] trait CassandraReplicationProgressStatements extends CassandraStatements {
+  def createReplicationProgressTableStatement = s"""
+      CREATE TABLE IF NOT EXISTS ${replicationProgressTable} (
+        log_id text,
+        source_log_id text,
+        source_log_read_pos bigint,
+        PRIMARY KEY (log_id, source_log_id))
+    """
+
+  def writeReplicationProgressStatement: String = s"""
+      INSERT INTO ${replicationProgressTable} (log_id, source_log_id, source_log_read_pos)
+      VALUES (?, ?, ?)
+    """
+
+  def readReplicationProgressStatement: String =  s"""
+      SELECT * FROM ${replicationProgressTable} WHERE
+        log_id = ?
+    """
+
+  def replicationProgressTable = table("rp")
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/package.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/package.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log
+
+import java.util.concurrent.Executor
+
+import com.google.common.util.concurrent.ListenableFuture
+
+import scala.language.implicitConversions
+import scala.concurrent._
+import scala.util.Try
+
+package object cassandra {
+  implicit def listenableFutureToFuture[A](lf: ListenableFuture[A])(implicit executionContext: ExecutionContext): Future[A] = {
+    val promise = Promise[A]
+    lf.addListener(new Runnable { def run() = promise.complete(Try(lf.get())) }, executionContext.asInstanceOf[Executor])
+    promise.future
+  }
+}

--- a/src/multi-jvm/resources/log4j.properties
+++ b/src/multi-jvm/resources/log4j.properties
@@ -1,0 +1,3 @@
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.SimpleLayout

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationSpec.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationSpec.scala
@@ -17,15 +17,28 @@
 package com.rbmhtechnology.eventuate
 
 import akka.actor._
+import akka.remote.testconductor.RoleName
 import akka.remote.testkit._
 import akka.testkit.TestProbe
+
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLogMultiNodeSupport
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLogMultiNodeSupport
 
 import scala.collection.immutable.Seq
 import scala.util._
 
-class BasicReplicationSpecMultiJvmNode1 extends BasicReplicationSpec
-class BasicReplicationSpecMultiJvmNode2 extends BasicReplicationSpec
-class BasicReplicationSpecMultiJvmNode3 extends BasicReplicationSpec
+class BasicReplicationSpecLeveldb extends BasicReplicationSpec with LeveldbEventLogMultiNodeSupport
+class BasicReplicationSpecLeveldbMultiJvmNode1 extends BasicReplicationSpecLeveldb
+class BasicReplicationSpecLeveldbMultiJvmNode2 extends BasicReplicationSpecLeveldb
+class BasicReplicationSpecLeveldbMultiJvmNode3 extends BasicReplicationSpecLeveldb
+
+class BasicReplicationSpecCassandra extends BasicReplicationSpec with CassandraEventLogMultiNodeSupport {
+  override def coordinator: RoleName = BasicReplicationConfig.nodeA
+  override def logName = "br"
+}
+class BasicReplicationSpecCassandraMultiJvmNode1 extends BasicReplicationSpecCassandra
+class BasicReplicationSpecCassandraMultiJvmNode2 extends BasicReplicationSpecCassandra
+class BasicReplicationSpecCassandraMultiJvmNode3 extends BasicReplicationSpecCassandra
 
 object BasicReplicationConfig extends MultiNodeConfig {
   val nodeA = role("nodeA")
@@ -50,10 +63,9 @@ object BasicReplicationSpec {
   }
 }
 
-class BasicReplicationSpec extends MultiNodeSpec(BasicReplicationConfig) with MultiNodeWordSpec with MultiNodeReplicationEndpoint {
+abstract class BasicReplicationSpec extends MultiNodeSpec(BasicReplicationConfig) with MultiNodeWordSpec with MultiNodeReplicationEndpoint {
   import BasicReplicationConfig._
   import BasicReplicationSpec._
-  import ReplicationEndpoint._
 
   def initialParticipants: Int =
     roles.size

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/FilteredReplicationSpec.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/FilteredReplicationSpec.scala
@@ -17,13 +17,25 @@
 package com.rbmhtechnology.eventuate
 
 import akka.actor._
+import akka.remote.testconductor.RoleName
 import akka.remote.testkit._
 import akka.testkit.TestProbe
 
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLogMultiNodeSupport
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLogMultiNodeSupport
+
 import scala.util._
 
-class FilteredReplicationSpecMultiJvmNode1 extends FilteredReplicationSpec
-class FilteredReplicationSpecMultiJvmNode2 extends FilteredReplicationSpec
+class FilteredReplicationSpecLeveldb extends FilteredReplicationSpec with LeveldbEventLogMultiNodeSupport
+class FilteredReplicationSpecLeveldbMultiJvmNode1 extends FilteredReplicationSpecLeveldb
+class FilteredReplicationSpecLeveldbMultiJvmNode2 extends FilteredReplicationSpecLeveldb
+
+class FilteredReplicationSpecCassandra extends FilteredReplicationSpec with CassandraEventLogMultiNodeSupport {
+  override def coordinator: RoleName = FilteredReplicationConfig.nodeA
+  override def logName = "fr"
+}
+class FilteredReplicationSpecCassandraMultiJvmNode1 extends FilteredReplicationSpecCassandra
+class FilteredReplicationSpecCassandraMultiJvmNode2 extends FilteredReplicationSpecCassandra
 
 object FilteredReplicationConfig extends MultiNodeConfig {
   val nodeA = role("nodeA")
@@ -53,10 +65,9 @@ object FilteredReplicationSpec {
   }
 }
 
-class FilteredReplicationSpec extends MultiNodeSpec(FilteredReplicationConfig) with MultiNodeWordSpec with MultiNodeReplicationEndpoint {
+abstract class FilteredReplicationSpec extends MultiNodeSpec(FilteredReplicationConfig) with MultiNodeWordSpec with MultiNodeReplicationEndpoint {
   import FilteredReplicationConfig._
   import FilteredReplicationSpec._
-  import ReplicationEndpoint._
 
   def initialParticipants: Int =
     roles.size

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
@@ -23,11 +23,16 @@ object MultiNodeReplicationConfig {
     val defaultConfig = ConfigFactory.parseString(
       s"""
          |akka.test.single-expect-default = 10s
+         |akka.testconductor.barrier-timeout = 60s
          |akka.loglevel = "ERROR"
          |
          |eventuate.log.replication.batch-size-max = 3
          |eventuate.log.replication.retry-interval = 1s
          |eventuate.log.replication.failure-detection-limit = 60s
+         |
+         |eventuate.log.cassandra.default-port = 9142
+         |eventuate.log.cassandra.index-update-limit = 3
+         |eventuate.log.cassandra.table-prefix = mnt
        """.stripMargin)
 
     ConfigFactory.parseString(customConfig).withFallback(defaultConfig)

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogMultiNodeSupport.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogMultiNodeSupport.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import akka.actor.Props
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeSpec
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+
+trait CassandraEventLogMultiNodeSupport { this: MultiNodeSpec =>
+  def coordinator: RoleName
+
+  def logProps(logId: String): Props =
+    CassandraEventLog.props(logId)
+
+  override def atStartup(): Unit = {
+    if (isNode(coordinator)) {
+      EmbeddedCassandraServerHelper.startEmbeddedCassandra(60000)
+      Cassandra(system)
+    }
+    enterBarrier("startup")
+  }
+
+  override def afterTermination(): Unit = {
+    if (isNode(coordinator)) EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+  }
+}

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbEventLogMultiNodeSupport.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbEventLogMultiNodeSupport.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.leveldb
+
+import java.io.File
+
+import akka.actor.Props
+import akka.remote.testkit.MultiNodeSpec
+
+import com.rbmhtechnology.eventuate.MultiNodeWordSpec
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.BeforeAndAfterAll
+
+trait LeveldbEventLogMultiNodeSupport extends BeforeAndAfterAll { this: MultiNodeSpec with MultiNodeWordSpec =>
+  private val logPrefix = "log"
+  private var logId = ""
+
+  def logProps(logId: String): Props = {
+    this.logId = logId
+    LeveldbEventLog.props(logId, logPrefix)
+  }
+
+  override def afterAll(): Unit = {
+    // get all config data before shutting down node
+    val logRootDir = new File(system.settings.config.getString("eventuate.log.leveldb.dir"))
+    val logDir = new File(logRootDir, s"${logPrefix}-${logId}")
+
+    // shut down node
+    super.afterAll()
+
+    // delete log files
+    FileUtils.deleteDirectory(logDir)
+  }
+
+}

--- a/src/sphinx/architecture.rst
+++ b/src/sphinx/architecture.rst
@@ -20,7 +20,7 @@ Eventuate applications store events in event logs. An event log can be replicate
 
    An event log, replicated across locations 1, 2 and 3.
 
-Events within a local log are totally ordered. This total order however is likely to differ among locations, as events can be written concurrently. The strongest ordering guarantee that can be given across locations is `causal ordering`_\ [#]_ which is tracked with `vector clocks`_. Causal ordering is guaranteed to be consistent with total ordering in local event logs. 
+Events within a local log are totally ordered. This total order however is likely to differ among locations, as events can be written concurrently. The strongest ordering guarantee that can be given across locations is `causal ordering`_\ [#]_ which is tracked with `vector clocks`_. Causal ordering is guaranteed to be consistent with total ordering in local event logs. Eventuate chooses write-availability over strong consistency for replicated event logs, giving up global total ordering for causal ordering.
 
 A replication endpoint can also manage more than one local event log. Event logs are indexed by name and replication occurs only between logs of the same name. Logs with different names are isolated from each other\ [#]_ and their distribution across locations may differ, as shown in the following figure.
 
@@ -31,9 +31,7 @@ A replication endpoint can also manage more than one local event log. Event logs
 
    Three replicated event logs. Log X (blue) is replicated across locations 1, 2 and 3. Log Y (red) is replicated across locations 1 and 2 and log Z (green) is replicated across locations 1 and 3.
 
-Eventuate event logs are comparable to `Apache Kafka`_ topics. The main difference is that Kafka chooses consistency over write-availability for replicated topics whereas Eventuate chooses write-availability over consistency for replicated event logs, giving up total ordering for causal ordering.
-
-Event storage backends at individual locations are pluggable. A location that requires strong durability guarantees should use a storage backend that is (synchronously) replicated within that location (`Apache Kafka`_ is an good fit here), others may use a more lightweight, non-replicated storage backend in case of weaker durability requirements.
+Event storage backends at individual locations are pluggable (see also :ref:`current-limitations`). A location that requires strong durability guarantees should use a storage backend that synchronously replicates events within that location (like the :ref:`cassandra-storage-backend`), others may use a more lightweight, non-replicated storage backend in case of weaker durability requirements (like the :ref:`leveldb-storage-backend`).
 
 Event replication across locations is reliable. Should a location crash or a network partition occur, replication automatically resumes when crashed location recovers and/or the partition heals. Built-in failure detectors inform applications about (un)availability of other locations. Replication endpoints also ensure that no duplicates are ever written to target event logs.
 

--- a/src/sphinx/code/EventLogDoc.scala
+++ b/src/sphinx/code/EventLogDoc.scala
@@ -16,8 +16,8 @@
 
 package doc
 
-trait LocalEventLogDoc {
-  //#local-log
+trait LocalEventLogLeveldbDoc {
+  //#local-log-leveldb
   import akka.actor.ActorSystem
   import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog
 
@@ -25,8 +25,22 @@ trait LocalEventLogDoc {
   //#
     ActorSystem("location")
 
-  //#local-log
-  val log = system.actorOf(LeveldbEventLog.props(id = "L1", prefix = "log"))
+  //#local-log-leveldb
+  val log = system.actorOf(LeveldbEventLog.props(logId = "L1", prefix = "log"))
+  //#
+}
+
+trait LocalEventLogCassandraDoc {
+  //#local-log-cassandra
+  import akka.actor.ActorSystem
+  import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLog
+
+  val system: ActorSystem = // ...
+  //#
+    ActorSystem("location")
+
+  //#local-log-cassandra
+  val log = system.actorOf(CassandraEventLog.props(logId = "L1"))
   //#
 }
 

--- a/src/sphinx/conf/common.conf
+++ b/src/sphinx/conf/common.conf
@@ -2,6 +2,14 @@
 eventuate.log.leveldb.dir = /var/eventuate
 //#
 
+//#cassandra-contact-points
+eventuate.log.cassandra.contact-points = [host1[:port1], host2[:port2], ...]
+//#
+
+//#cassandra-default-port
+eventuate.log.cassandra.default-port = 9042
+//#
+
 //#failure-detection-limit
 eventuate.log.replication.failure-detection-limit = 60s
 //#

--- a/src/sphinx/current-limitations.rst
+++ b/src/sphinx/current-limitations.rst
@@ -24,7 +24,7 @@ The following is a list of known limitations that are going to be addressed in f
 
 - Replication network topologies must be statically defined at the moment. Dynamic changes, such add adding new locations at runtime, will be supported in future versions. We also think about an integration with `Akka Cluster`_.
 
-- The only supported event log storage backend at the moment is LevelDB_. There will be a plugin API in the future together with a default implementation of a replicated storage backend.
+- The storage plugin API is not public yet. Applications can currently choose between a LevelDB_ and Cassandra_ storage backend. The drivers for these backends are packaged with Eventuate and section :ref:`event-log` describes their usage.
 
 - Event routing is limited at the moment. In addition to event broadcast and ``aggregateId``-based collaboration groups, there is `direct event routing`_ supported but `advanced event routing`_ will come in a later release.
 
@@ -36,6 +36,7 @@ The following is a list of known limitations that are going to be addressed in f
 
 .. _Akka Cluster: http://doc.akka.io/docs/akka/2.3.9/scala/cluster-usage.html
 .. _Akka Remoting: http://doc.akka.io/docs/akka/2.3.9/scala/remoting.html
+.. _Cassandra: http://cassandra.apache.org/
 .. _LevelDB: https://github.com/google/leveldb
 .. _NAT: http://de.wikipedia.org/wiki/Network_Address_Translation
 .. _let us know: https://groups.google.com/forum/#!forum/eventuate

--- a/src/sphinx/introduction.rst
+++ b/src/sphinx/introduction.rst
@@ -10,17 +10,20 @@ Eventuate is a toolkit for building distributed, highly-available and partition-
 
 Eventuate supports replication of application state through asynchronous event replication across *locations*. These can be geographically distinct locations, nodes within a data center or even processes on the same node, for example. Locations consume replicated events to re-construct application state locally. Eventuate allows multiple locations to concurrently update replicated application state (multi-master setup) and supports automated and interactive conflict resolution strategies in case of conflicting updates. This is known as operation-based `optimistic replication`_ where operations are represented by application-defined events.
 
-Events captured at a location are stored in a local event log and replicated asynchronously to other locations based on a replication protocol that preserves a `causal ordering`_ of events. Causality is tracked with `vector clocks`_. For any two events, applications can determine if they have a causal relationship or if they are concurrent by comparing their vector timestamps. This is important to achieve `causal consistency`_ of replicated application state.
+Events captured at a location are stored in a local event log and replicated asynchronously to other locations based on a replication protocol that preserves a `causal ordering`_ of events. Causality is tracked with `vector clocks`_. For any two events, applications can determine if they have a causal relationship or if they are concurrent by comparing their vector timestamps. This is important to achieve `causal consistency`_ which is the strongest possible consistency for “always-on” applications i.e. applications that should remain available for writes during network partitions\ [#]_.
 
 Individual locations remain available for local writes during inter-location network partitions. Events that have been captured locally during a network partition are replicated later when the partition heals. Storing events locally and replicating them later can also be useful for distributed applications deployed on temporarily connected devices, for example.
 
-Storage technologies at individual locations are pluggable (SPI not defined yet). A location deployed on a mobile device, for example, will probably choose to write a filtered subset of events to the local filesystem whereas a location deployed in a data center could choose to write events to an `Apache Kafka`_ cluster. Event replication across locations is independent of the storage technologies used at individual locations, so that distributed applications with hybrid event stores are possible.
+Storage technologies at individual locations are pluggable (see also :ref:`current-limitations`). A location deployed on a mobile device, for example, will probably choose to write a filtered subset of events to the local filesystem whereas a location deployed in a data center could choose to write events to a Cassandra_ cluster. Event replication across locations is independent of the storage technologies used at individual locations, so that distributed applications with hybrid event stores are possible.
 
 To model application state, any custom data type can be used. Applications just need to ensure that projecting events from a causally ordered event stream onto these data types yield a consistent result. This may involve detection of conflicts from concurrent events, selecting one of the conflicting versions as the winner or even merging them, for which Eventuate provides utilities. Eventuate also provides implementations_ of operation-based CRDT_\ s, specially-designed data structures used to achieve `strong eventual consistency`_.
 
+.. [#] Wyatt Lloyd et al, `Don’t settle for Eventual`_: Scalable Causal Consistency for Wide-Area Storage with COPS
+
 .. _Scala: http://www.scala-lang.org/
 .. _Akka: http://akka.io
-.. _Apache Kafka: http://kafka.apache.org/
+.. _Cassandra: http://cassandra.apache.org/
+.. _LevelDB: https://github.com/google/leveldb
 .. _Event sourcing: http://martinfowler.com/eaaDev/EventSourcing.html
 .. _CAP: http://en.wikipedia.org/wiki/CAP_theorem
 .. _CRDT: http://en.wikipedia.org/wiki/Conflict-free_replicated_data_type 
@@ -31,3 +34,5 @@ To model application state, any custom data type can be used. Applications just 
 .. _implementations: https://krasserm.github.io/2015/02/17/Implementing-operation-based-CRDTs/
 .. _vector clocks: http://en.wikipedia.org/wiki/Vector_clock
 .. _strong eventual consistency: http://en.wikipedia.org/wiki/Eventual_consistency#Strong_eventual_consistency
+
+.. _Don’t settle for Eventual: https://www.cs.cmu.edu/~dga/papers/cops-sosp2011.pdf

--- a/src/sphinx/reference/event-log.rst
+++ b/src/sphinx/reference/event-log.rst
@@ -8,21 +8,53 @@ Event log
 Local event log
 ~~~~~~~~~~~~~~~
 
-A local event log belongs to a given *location*\ [#]_ and a location can have one or more local event logs. Depending on the backend store, a local event log may optionally be replicated within that location for stronger durability guarantees but this is rather an implementation details of the local event log. From Eventuate’s perspective, event replication occurs between different locations which is further described in section :ref:`replicated-event-log`.
+A local event log belongs to a given *location*\ [#]_ and a location can have one or more local event logs. Depending on the storage backend, a local event log may optionally be replicated within that location for stronger durability guarantees but this is rather an implementation details of the local event log. From Eventuate’s perspective, event replication occurs between different locations which is further described in section :ref:`replicated-event-log`.
 
 To an application, an event log is represented by an event log actor. Producers and consumer interact with that actor to write events to and read events from an event log. They can also register at the event log actor to be notified about newly written events. The messages that can be exchanged with an event log actor are defined in EventsourcingProtocol_.
 
-A local event log actor with a LevelDB backend store can be created with:
+At the moment, two storage backends are supported by Eventuate, `LevelDB`_ and `Cassandra`_. The corresponding event log actors are provided by Eventuate and their usage is explained in the following sections.
+
+.. _leveldb-storage-backend:
+
+LevelDB storage backend
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A local event log actor with a LevelDB storage backend writes events to the local file system. It can be created with:
 
 .. includecode:: ../code/EventLogDoc.scala
-   :snippet: local-log
+   :snippet: local-log-leveldb
 
-Applications must provide a unique ``id`` for that log, the prefix is optional and defaults to ``log``. This will create a directory ``log-L1`` in which the LevelDB files are stored. The root directory of all local LevelDB directories can be configured with the ``eventuate.log.leveldb.dir`` configuration key in ``application.conf``:
+Applications must provide a unique ``logId`` for that log, the ``prefix`` is optional and defaults to ``log``. This will create a directory ``log-L1`` in which the LevelDB files are stored. The root directory of all local LevelDB directories can be configured with the ``eventuate.log.leveldb.dir`` configuration key in ``application.conf``:
 
 .. includecode:: ../conf/common.conf
    :snippet: leveldb-root-dir
 
-With this configuration, the absolute path of the LevelDB directory in the above example is ``/var/eventuate/log-L1``. If not configured, ``eventuate.log.leveldb.dir`` defaults to ``target``.
+With this configuration, the absolute path of the LevelDB directory in the above example is ``/var/eventuate/log-L1``. If not configured, ``eventuate.log.leveldb.dir`` defaults to ``target``. Further ``eventuate.log.leveldb`` configuration options are given in section :ref:`configuration`.
+
+.. _cassandra-storage-backend:
+
+Cassandra storage backend
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A local event log actor with a Cassandra storage backend writes events to a Cassandra cluster. The event log actor can be created with:
+
+.. includecode:: ../code/EventLogDoc.scala
+   :snippet: local-log-cassandra
+
+With default configuration settings the event log actor connects to a Cassandra node at ``127.0.0.1:9042``. This can be customized with
+
+.. includecode:: ../conf/common.conf
+   :snippet: cassandra-contact-points
+
+Ports are optional and default to ``9042`` according to
+
+.. includecode:: ../conf/common.conf
+   :snippet: cassandra-default-port
+
+Further details are described in the API docs of the `Cassandra extension`_ and the CassandraEventLog_ actor. A complete reference of ``eventuate.log.cassandra`` configuration options is given in section :ref:`configuration`.
+
+.. note::
+   Eventuate requires Cassandra version 2.1 or higher.
 
 .. _replicated-event-log:
 
@@ -141,6 +173,8 @@ Both messages are defined in ReplicationEndpoint_. Their ``endpointId`` paramete
 
 It instructs the failure detector to publish an ``Unavailable`` message if there is no heartbeat from the remote replication endpoint within 60 seconds. ``Available`` and ``Unavailable`` messages are published periodically at intervals of ``eventuate.log.replication.failure-detection-limit``.
 
+.. _Cassandra: http://cassandra.apache.org/
+.. _LevelDB: https://github.com/google/leveldb
 .. _Akka Remoting: http://doc.akka.io/docs/akka/2.3.9/scala/remoting.html
 .. _event stream: http://doc.akka.io/docs/akka/2.3.9/scala/event-bus.html#event-stream
 
@@ -149,6 +183,8 @@ It instructs the failure detector to publish an ``Unavailable`` message if there
 .. _ReplicationConnection: ../latest/api/index.html#com.rbmhtechnology.eventuate.ReplicationConnection$
 .. _ReplicationFilter: ../latest/api/index.html#com.rbmhtechnology.eventuate.ReplicationFilter
 .. _DurableEvent: ../latest/api/index.html#com.rbmhtechnology.eventuate.DurableEvent
+.. _Cassandra extension: ../latest/api/index.html#com.rbmhtechnology.eventuate.log.cassandra.Cassandra
+.. _CassandraEventLog: ../latest/api/index.html#com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLog
 
 .. [#] A location can be a whole data center, a node within a data center or even a process on a single node, for example.
 .. [#] Log names must be unique per replication endpoint. Replication connections are only established between logs of the same name.

--- a/src/sphinx/reference/event-sourcing.rst
+++ b/src/sphinx/reference/event-sourcing.rst
@@ -51,7 +51,7 @@ If a sender sends an update command followed by a read command to an event-sourc
    .. includecode:: ../code/EventSourcingDoc.scala
       :snippet: delay-signature
 
-   It delays processing of a command to that point in the future where all previously ``persist``\ ed events have been handled. The delayed command is passed as argument to the delay ``handler``\ [#]_. A delay handler must not call ``persist`` or related methods.
+   It delays processing of a command to that point in the future where all previously ``persist``\ ed events have been handled. The delayed command is passed as argument to the delay ``handler``. A delay handler must not call ``persist`` or related methods.
 
 .. hint::
    For details about the ``delay`` method, refer to the EventsourcedActor_ API documentation. 
@@ -169,7 +169,6 @@ Custom replication filter serialization also works if the custom filter is part 
 .. [#] An explicit ``onEvent`` call may become obsolete in future releases.
 .. [#] The ``customRoutingDestinations`` parameter is described in section :ref:`event-routing`.
 .. [#] Writes from different event-sourced actors that have ``stateSync`` set to ``true`` are still batched, but not the writes from a single event-sourced actor.
-.. [#] This mechanism of delaying commands might the replaced with something that is closer related to :ref:`conditional-commands` in future releases.
 .. [#] Event replay can optionally start from :ref:`snapshots` of actor state.
 .. [#] :ref:`processors` can additionally route events between event logs.
 .. [#] The routing destinations of a DurableEvent_ can be obtained with method ``routingDestinations``.

--- a/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedActorSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedActorSpec.scala
@@ -436,13 +436,11 @@ class EventsourcedActorSpec extends TestKit(ActorSystem("test")) with WordSpecLi
         actor ! CmdDelayed("b")
         actor ! Cmd("c")
         val write1 = logProbe.expectMsgClass(classOf[Write])
-        val delay = logProbe.expectMsgClass(classOf[Delay])
         val write2 = logProbe.expectMsgClass(classOf[Write])
         actor ! WriteSuccess(write1.events(0).copy(targetLogSequenceNr = 1L), instanceId)
-        actor ! DelayComplete(delay.commands(0), instanceId)
-        actor ! WriteSuccess(write2.events(0).copy(targetLogSequenceNr = 2L), instanceId)
         dstProbe.expectMsg(("a-1", timestampA(2), timestampA(1), 1))
         dstProbe.expectMsg(("b", timestampA(2), timestampA(1), 1))
+        actor ! WriteSuccess(write2.events(0).copy(targetLogSequenceNr = 2L), instanceId)
         dstProbe.expectMsg(("c-1", timestampA(2), timestampA(2), 2))
       }
     }

--- a/src/test/scala/com/rbmhtechnology/example/OrderExample.scala
+++ b/src/test/scala/com/rbmhtechnology/example/OrderExample.scala
@@ -23,11 +23,13 @@ import com.rbmhtechnology.eventuate.VersionedAggregate._
 import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog
 import com.typesafe.config.ConfigFactory
 
+import scala.io.Source
+
 class OrderExample(manager: ActorRef, view: ActorRef) extends Actor {
   import OrderActor._
   import OrderView._
 
-  val lines = io.Source.stdin.getLines
+  val lines = Source.stdin.getLines
 
   def receive = {
     case GetStateSuccess(state) =>


### PR DESCRIPTION
- persistent log
   - atomic event batch writes
- persistent index
   - aggregate events,
   - replication progress
   - indexing progress
   - asynchronously written
- closes #62

Current limitations:

- event logs are not partitioned yet
  (will be tracked by a separate ticket)

Further changes:

- idempotent replicator
   - remove obsolete correlationId fields
   - remove idempotent replication write processing from LeveldbEventLog
- re-implement EventsourcedActor.delay with conditional commands
- increase write batch sizes under moderate loads
   - batch layer gets notified after writes completed
   - gives batching layer more time to accumulate writes
- run all integration and multi-node tests with LevelDB and Cassandra
- fix wrong assumptions in collaboration test
   - fixes #65
- fix timing issue in ReplicatedORSetSpec
   - fixes #69