### PR TITLE
Cassandra: do not wait for system termination

### DIFF
--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
@@ -138,7 +138,12 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
     _session.execute(createReplicationProgressTableStatement)
   } match {
     case Success(_) => logging.info("Cassandra extension initialized")
-    case Failure(e) => logging.error(e, "Cassandra extension initialization failed."); Await.result(terminate(), Duration.Inf) // TODO: retry
+    case Failure(e) =>
+      logging.error(e, "Cassandra extension initialization failed.")
+      // TODO: as soon as there is a retry mechanism or a dedicated exception
+      // TODO: there is no reason to terminate the actor system anymore
+      terminate()
+      throw e
   }
 
   /**


### PR DESCRIPTION
Hi there,

in case of a failure in the cassandra extension initialization we rather throw an exception than waiting (indefinitely) for the actor system to shut down.

As of now a process that fails to connect to the cassandra cluster will indefinitely wait until being killed by `kill -9`.

Cheers,
Gregor