### PR TITLE
Optional source log update notifications

### DIFF
--- a/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
@@ -50,7 +50,7 @@ object RecoverySpec {
   val config =
     """
       |eventuate.log.replication.read-timeout = 2s
-      |eventuate.log.replication.retry-interval = 1s
+      |eventuate.log.replication.retry-delay = 1s
       |eventuate.disaster-recovery.remote-operation-retry-max = 10
       |eventuate.disaster-recovery.remote-operation-retry-delay = 1s
       |eventuate.disaster-recovery.remote-operation-timeout = 1s

--- a/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
@@ -37,7 +37,7 @@ object ReplicationConfig {
          |eventuate.log.cassandra.default-port = 9142
          |eventuate.log.cassandra.index-update-limit = 3
          |eventuate.log.replication.batch-size-max = 3
-         |eventuate.log.replication.retry-interval = 1s
+         |eventuate.log.replication.retry-delay = 1s
          |eventuate.log.replication.failure-detection-limit = 3s
        """.stripMargin)
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -54,9 +54,9 @@ eventuate {
     # event log.
     batch-size-max = 512
 
-    # Event replication retry interval. Event replication is re-tried at this
-    # interval if previous transfer batch was empty or failed.
-    retry-interval = 5s
+    # Event replication retry delay. Event replication is delayed for the
+    # given duration if a previous transfer batch was empty or failed.
+    retry-delay = 5s
 
     # Timeout for reading events from the remote source log.
     read-timeout = 10s
@@ -67,6 +67,14 @@ eventuate {
     # Maximum duration of missing heartbeats from a remote location until
     # that location is considered unavailable.
     failure-detection-limit = 60s
+
+    # If turned on, notifications about updates in a source event log are sent
+    # to remote replication endpoints which reduces event replication latency.
+    # The impact of sending update notifications on average replication latency
+    # decreases with increasing event write load. Applications with high event
+    # write load may even experience increased event replication throughput if
+    # update notifications are turned off.
+    update-notifications = on
   }
 
   log.leveldb {

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationThroughputSpec.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationThroughputSpec.scala
@@ -55,7 +55,7 @@ object BasicReplicationThroughputConfig extends MultiNodeConfig {
       |akka.remote.netty.tcp.maximum-frame-size = 1048576b
       |
       |eventuate.log.replication.batch-size-max = 2000
-      |eventuate.log.replication.retry-interval = 10s
+      |eventuate.log.replication.retry-delay = 10s
       |eventuate.log.cassandra.index-update-limit = 200
     """.stripMargin))
 }

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
@@ -27,7 +27,7 @@ object MultiNodeReplicationConfig {
          |akka.loglevel = "ERROR"
          |
          |eventuate.log.replication.batch-size-max = 3
-         |eventuate.log.replication.retry-interval = 1s
+         |eventuate.log.replication.retry-delay = 1s
          |eventuate.log.replication.failure-detection-limit = 60s
          |
          |eventuate.snapshot.filesystem.dir = target/test-snapshot

--- a/src/sphinx/conf/common.conf
+++ b/src/sphinx/conf/common.conf
@@ -23,6 +23,14 @@ eventuate.log.replication.failure-detection-limit = 60s
 eventuate.log.replication.batch-size-max = 512
 //#
 
+//#retry-delay
+eventuate.log.replication.retry-delay = 5s
+//#
+
+//#update-notifications
+eventuate.log.replication.update-notifications = on
+//#
+
 //#maximum-frame-size
 akka.remote.netty.tcp.maximum-frame-size = 128000b
 //#

--- a/src/sphinx/example-application.rst
+++ b/src/sphinx/example-application.rst
@@ -108,7 +108,7 @@ or the Java version with::
 Recovery may take up to 20 seconds when using the default :ref:`configuration` settings for event replication and disaster recovery. To speed up the process you may want to the use following configuration settings::
 
     eventuate.log.replication.read-timeout = 2s
-    eventuate.log.replication.retry-interval = 1s
+    eventuate.log.replication.retry-delay = 1s
     eventuate.disaster-recovery.remote-operation-retry-max = 10
     eventuate.disaster-recovery.remote-operation-retry-delay = 1s
     eventuate.disaster-recovery.remote-operation-timeout = 1s

--- a/src/sphinx/reference/event-log.rst
+++ b/src/sphinx/reference/event-log.rst
@@ -189,7 +189,24 @@ Applications that increase the maximum batch size and/or store rather large even
 .. includecode:: ../conf/common.conf
    :snippet: maximum-frame-size
 
-otherwise, replication will fail.
+otherwise, replication may fail.
+
+.. _update-notifications:
+
+Update notifications
+^^^^^^^^^^^^^^^^^^^^
+
+After having replicated a non-empty event batch, a replication endpoint immediately makes another replication attempt. On the other hand, if the replicated event batch is empty, the next replication attempt is delayed by a duration that can be configured with:
+
+.. includecode:: ../conf/common.conf
+   :snippet: retry-delay
+
+Consequently, event replication latency has an upper bound that is determined by this parameter. To minimize event replication latency, replication endpoints by default send event log update notifications to each other. The corresponding configuration parameter is:
+
+.. includecode:: ../conf/common.conf
+   :snippet: update-notifications
+
+The impact of sending update notifications on average event replication latency, however, decreases with increasing event write load. Applications under high event write load may even experience increased event replication throughput if update notifications are turned ``off``.
 
 Failure detection
 ^^^^^^^^^^^^^^^^^

--- a/src/test/scala/com/rbmhtechnology/eventuate/log/NotificationChannelSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/log/NotificationChannelSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log
+
+import akka.actor._
+import akka.testkit._
+
+import com.rbmhtechnology.eventuate._
+import com.rbmhtechnology.eventuate.ReplicationFilter._
+import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.rbmhtechnology.eventuate.log.NotificationChannel._
+
+import org.scalatest._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+
+object NotificationChannelSpec {
+  class PayloadFilter(accept: Any) extends ReplicationFilter {
+    override def apply(event: DurableEvent): Boolean =
+      event.payload == accept
+  }
+
+  val timeout = 0.2.seconds
+
+  val sourceLogId = "slid"
+  val targetLogId1 = "tlid1"
+  val targetLogId2 = "tlid2"
+
+  def event(payload: Any, vectorTimestamp: VectorTime): DurableEvent =
+    DurableEvent(payload, "emitter", vectorTimestamp = vectorTimestamp)
+
+  def vectorTime(s: Long, t1: Long, t2: Long) =
+    VectorTime(sourceLogId -> s, targetLogId1 -> t1, targetLogId2 -> t2)
+}
+
+class NotificationChannelSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+  import NotificationChannelSpec._
+
+  private var channel: ActorRef = _
+  private var probe: TestProbe = _
+
+  override def afterAll(): Unit =
+    TestKit.shutdownActorSystem(system)
+
+  override def beforeEach(): Unit = {
+    channel = system.actorOf(Props(new NotificationChannel(sourceLogId)))
+    probe = TestProbe()
+  }
+
+  def sourceRead(targetLogId: String, targetVersionVector: VectorTime, filter: ReplicationFilter = NoFilter, probe: TestProbe = probe): Unit = {
+    channel ! sourceReadMessage(targetLogId, targetVersionVector, filter, probe)
+    channel ! sourceReadSuccessMessage(targetLogId)
+  }
+
+  def sourceReadMessage(targetLogId: String, targetVersionVector: VectorTime, filter: ReplicationFilter = NoFilter, probe: TestProbe = probe): ReplicationRead =
+    ReplicationRead(1L, 10, filter, targetLogId, probe.ref, targetVersionVector)
+
+  def sourceReadSuccessMessage(targetLogId: String): ReplicationReadSuccess =
+    ReplicationReadSuccess(Nil, 10L, targetLogId, VectorTime.Zero)
+
+  def sourceUpdate(events: Seq[DurableEvent]): Unit =
+    channel ! Updated(events)
+
+  def replicaVersionUpdate(targetLogId: String, targetVersionVector: VectorTime): Unit =
+    channel ! ReplicationWrite(Nil, targetLogId, 10L, targetVersionVector)
+
+  "A notification channel" must {
+    "send a notification if an update is not the causal past of the target" in {
+      sourceRead(targetLogId1, vectorTime(0, 1, 0))
+      sourceUpdate(Seq(event("a", vectorTime(1, 0, 0))))
+
+      probe.expectMsg(ReplicationDue)
+      probe.expectNoMsg(timeout)
+    }
+    "send a notification if part of an update is not in the causal past of the target" in {
+      sourceRead(targetLogId1, vectorTime(0, 1, 0))
+      sourceUpdate(Seq(
+        event("a", vectorTime(0, 1, 0)),
+        event("b", vectorTime(1, 0, 0))))
+
+      probe.expectMsg(ReplicationDue)
+      probe.expectNoMsg(timeout)
+    }
+    "not send a notification if an update is in the causal past of the target" in {
+      sourceRead(targetLogId1, vectorTime(0, 2, 0))
+      sourceUpdate(Seq(
+        event("a", vectorTime(0, 1, 0)),
+        event("b", vectorTime(0, 2, 0))))
+
+      probe.expectNoMsg(timeout)
+    }
+    "not send a notification if an update does not pass the target's replication filter" in {
+      sourceRead(targetLogId1, vectorTime(0, 1, 0), new PayloadFilter("a"))
+      sourceUpdate(Seq(
+        event("a", vectorTime(1, 0, 0)),
+        event("b", vectorTime(2, 0, 0))))
+
+      probe.expectMsg(ReplicationDue)
+      probe.expectNoMsg(timeout)
+    }
+    "not send a notification if a target is currently running a replication read" in {
+      channel ! sourceReadMessage(targetLogId1, vectorTime(0, 1, 0))
+      sourceUpdate(Seq(
+        event("a", vectorTime(1, 0, 0)),
+        event("b", vectorTime(2, 0, 0))))
+
+      probe.expectNoMsg(timeout)
+    }
+    "apply target version vector updates " in {
+      sourceRead(targetLogId1, vectorTime(0, 1, 0))
+      sourceUpdate(Seq(event("a", vectorTime(0, 2, 0))))
+
+      probe.expectMsg(ReplicationDue)
+      probe.expectNoMsg(timeout)
+
+      replicaVersionUpdate(targetLogId1, vectorTime(0, 2, 0))
+      sourceUpdate(Seq(event("a", vectorTime(0, 2, 0))))
+
+      probe.expectNoMsg(timeout)
+    }
+    "send notification to several targets" in {
+      sourceRead(targetLogId1, vectorTime(0, 1, 0))
+      sourceRead(targetLogId2, vectorTime(0, 0, 1))
+      sourceUpdate(Seq(event("a", vectorTime(1, 0, 0))))
+
+      probe.expectMsg(ReplicationDue)
+      probe.expectMsg(ReplicationDue)
+      probe.expectNoMsg(timeout)
+    }
+  }
+}


### PR DESCRIPTION
 - can be turned on/off with the eventuate.log.replication.update-notifications configuration parameter
 - update notifications are turned on by default and should be turned off in high write load environments

- closes #117