### PR TITLE
Fix tracking event replication progress

### DIFF
--- a/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
@@ -30,7 +30,6 @@ import com.rbmhtechnology.eventuate.utilities._
 import org.apache.commons.io.FileUtils
 import org.scalatest._
 
-import scala.collection.breakOut
 import scala.concurrent.duration._
 
 object RecoverySpec {
@@ -113,25 +112,26 @@ class RecoverySpec extends WordSpec with Matchers with ReplicationNodeRegistry w
 
       an [Exception] shouldBe thrownBy(endpoint.recover().await)
     }
-    "succeed normally if the endpoint was healthy" in {
-      val nodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+    "succeed normally if the endpoint was healthy (but not convergent yet)" in {
+      def newNodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+      val nodeA = newNodeA
       val nodeB = node("B", Set("L1"), 2553, Set(replicationConnection(2552)))
 
-      nodeA.endpoint.activate()
-      nodeB.endpoint.activate()
       val targetA = nodeA.endpoint.target("L1")
       val targetB = nodeB.endpoint.target("L1")
 
-      write(targetA, (0 to 20).map("A" + _))
-      write(targetB, (0 to 20).map("B" + _))
+      write(targetA, List("a1", "a2"))
+      write(targetB, List("b1", "b2"))
+      replicate(targetA, targetB, 1)
+      replicate(targetB, targetA, 1)
 
-      Thread.sleep(50) // let some replication take place
       nodeA.terminate().await
-      val restartedA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+      val restartedA = newNodeA
 
+      nodeB.endpoint.activate()
       restartedA.endpoint.recover().await
 
-      assertConvergence((0 to 20).flatMap(i => Set(s"A$i", s"B$i"))(breakOut), restartedA, nodeB)
+      assertConvergence(Set("a1", "a2", "b1", "b2"), restartedA, nodeB)
     }
     "repair inconsistencies of an endpoint that has lost all events" in {
       val nodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2555)))
@@ -174,13 +174,15 @@ class RecoverySpec extends WordSpec with Matchers with ReplicationNodeRegistry w
       val nodeD2 = nodeD
 
       nodeD2.endpoint.recover().await
-      // disclose bug #152
+      // disclose bug #152 (writing new events is allowed after successful recovery)
       write(nodeD2.endpoint.target("L1"), List("d1"))
 
       assertConvergence(Set("a", "b", "c", "d", "d1"), nodeA, nodeB, nodeC, nodeD2)
     }
-    "repair inconsistencies if recovery was stopped and restarted" in {
-      val nodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+    "repair inconsistencies if recovery was stopped during event recovery and restarted" in {
+      def newNodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)),
+        customConfig = "eventuate.log.replication.batch-size-max = 1")
+      val nodeA = newNodeA
       val nodeB = node("B", Set("L1"), 2553, Set(replicationConnection(2552)))
 
       nodeA.endpoint.activate()
@@ -189,22 +191,26 @@ class RecoverySpec extends WordSpec with Matchers with ReplicationNodeRegistry w
       val logDirA = logDirectory(targetA)
       val targetB = nodeB.endpoint.target("L1")
 
-      write(targetA, (0 to 20).map("A" + _))
-      write(targetB, (0 to 20).map("B" + _))
-      assertConvergence((0 to 20).flatMap(i => Set(s"A$i", s"B$i"))(breakOut), nodeA, nodeB)
+      val as = (0 to 5).map("A" + _)
+      val bs = (0 to 5).map("B" + _)
+      val all = as.toSet ++ bs.toSet
+      write(targetA, as)
+      write(targetB, bs)
+      assertConvergence(all, nodeA, nodeB)
 
       nodeA.terminate().await
       FileUtils.deleteDirectory(logDirA)
 
-      val restartedA = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+      val restartedA = newNodeA
       restartedA.endpoint.recover()
-      Thread.sleep(2000) // Let some recovery take place
-      restartedA.terminate()
+      restartedA.eventListener("L1").waitForMessage("A1")
 
-      val restartedA2 = node("A", Set("L1"), 2552, Set(replicationConnection(2553)))
+      restartedA.terminate().await
+
+      val restartedA2 = newNodeA
       restartedA2.endpoint.recover().await
 
-      assertConvergence((0 to 20).flatMap(i => Set(s"A$i", s"B$i"))(breakOut), restartedA2, nodeB)
+      assertConvergence(all, restartedA2, nodeB)
     }
     "repair inconsistencies of an endpoint that has lost all events but has been partially recovered from a storage backup" in {
       val nodeA = node("A", Set("L1"), 2552, Set(replicationConnection(2555)))

--- a/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
@@ -141,13 +141,13 @@ trait EventLogSpecSupport extends WordSpecLike with Matchers with BeforeAndAfter
     val offset = currentSequenceNr + 1L
     val expected = expectedReplicatedEvents(events, offset)
     log.tell(ReplicationWrite(events, remoteLogId, replicationProgress, VectorTime()), replicatorProbe.ref)
-    replicatorProbe.expectMsgPF() { case ReplicationWriteSuccess(_, `replicationProgress`, _) => }
+    replicatorProbe.expectMsgPF() { case ReplicationWriteSuccess(_, _, `replicationProgress`, _) => }
     expected
   }
 
   def writeReplicationProgress(replicationProgress: Long, expectedStoredReplicationProgress: Long, remoteLogId: String = remoteLogId): Unit = {
     log.tell(ReplicationWrite(Seq(), remoteLogId, replicationProgress, VectorTime()), replicatorProbe.ref)
-    replicatorProbe.expectMsgPF() { case ReplicationWriteSuccess(0, `expectedStoredReplicationProgress`, _) => }
+    replicatorProbe.expectMsgPF() { case ReplicationWriteSuccess(0, _, `expectedStoredReplicationProgress`, _) => }
   }
 
   def registerCollaborator(aggregateId: Option[String] = None, collaborator: TestProbe = TestProbe()): TestProbe = {

--- a/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
@@ -110,8 +110,8 @@ trait EventsourcedProcessor extends EventsourcedWriter[Long, Long] {
   override final def write(): Future[Long] =
     if (lastSequenceNr > processingProgress) {
       val result = targetEventLog.ask(ReplicationWrite(processedEvents, id, lastSequenceNr, VectorTime.Zero))(Timeout(writeTimeout)).flatMap {
-        case ReplicationWriteSuccess(_, progress, _) => Future.successful(progress)
-        case ReplicationWriteFailure(cause)          => Future.failed(cause)
+        case ReplicationWriteSuccess(_, _, progress, _) => Future.successful(progress)
+        case ReplicationWriteFailure(cause)             => Future.failed(cause)
       }
       processedEvents = Vector.empty
       result

--- a/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
@@ -186,9 +186,11 @@ object ReplicationProtocol {
    * Success reply after a [[ReplicationWrite]].
    *
    * @param num Number of events actually replicated.
+   * @param sourceLogId id of the log the written events were replicated from
    * @param storedReplicationProgress Last source log read position stored in the target log.
+   * @param currentTargetVersionVector [[EventLogClock.versionVector]] of the target log after the events were written
    */
-  case class ReplicationWriteSuccess(num: Int, storedReplicationProgress: Long, currentTargetVersionVector: VectorTime)
+  case class ReplicationWriteSuccess(num: Int, sourceLogId: String, storedReplicationProgress: Long, currentTargetVersionVector: VectorTime)
 
   /**
    * Failure reply after a [[ReplicationWrite]].

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
@@ -398,7 +398,7 @@ abstract class EventLog[A](id: String) extends Actor with EventLogSPI[A] with St
       case Success((updatedWrites, updatedEvents, clock2)) =>
         clock = clock2
         updatedWrites.foreach { w =>
-          val rws = ReplicationWriteSuccess(w.size, w.replicationProgress, clock2.versionVector)
+          val rws = ReplicationWriteSuccess(w.size, w.sourceLogId, w.replicationProgress, clock2.versionVector)
           val sdr = w.initiator
           registry.pushReplicateSuccess(w.events)
           channel.foreach(_ ! w)

--- a/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedProcessorSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedProcessorSpec.scala
@@ -135,7 +135,7 @@ class EventsourcedProcessorSpec extends TestKit(ActorSystem("test")) with WordSp
   def processWrite(progress: Long, events: Seq[DurableEvent], success: Boolean = true): Unit = {
     trgProbe.expectMsg(ReplicationWrite(events, emitterIdB, progress, VectorTime()))
     if (success) {
-      processResult(ReplicationWriteSuccess(events.size, progress, VectorTime()))
+      processResult(ReplicationWriteSuccess(events.size, emitterIdB, progress, VectorTime()))
       appProbe.expectMsg(progress)
     } else {
       processResult(ReplicationWriteFailure(boom))


### PR DESCRIPTION
- Send notification about written replicated events from
  Replicator to Acceptor to track replication progress for
  event recovery
- remove Thread.sleep from tests to control flow more
  accurately
- closes #159