### PR TITLE
Support logical and physical deletion of events

### DIFF
--- a/.travis/test-it.sh
+++ b/.travis/test-it.sh
@@ -2,6 +2,7 @@
 
 sbt $1 "it:testOnly \
   com.rbmhtechnology.eventuate.RecoverySpec \
+  com.rbmhtechnology.eventuate.DeleteEventsSpec \
   com.rbmhtechnology.eventuate.crdt.* \
   com.rbmhtechnology.eventuate.serializer.* \
   com.rbmhtechnology.eventuate.snapshot.filesystem.* \

--- a/src/it/scala/com/rbmhtechnology/eventuate/DeleteEventsSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/DeleteEventsSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Props
+import com.rbmhtechnology.eventuate.ReplicationIntegrationSpec.replicationConnection
+import com.rbmhtechnology.eventuate.log.EventLogCleanupLeveldb
+import com.rbmhtechnology.eventuate.log.EventLogLifecycleLeveldb.TestEventLog
+import com.rbmhtechnology.eventuate.utilities.AwaitHelper
+
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+import scala.util.Failure
+import scala.util.Success
+
+object DeleteEventsSpec {
+  val L1 = "L1"
+
+  val portA = 2552
+  val connectedToA = replicationConnection(portA)
+
+  val portB = 2553
+  val connectedToB = replicationConnection(portB)
+
+  val portC = 2554
+  val connectedToC = replicationConnection(portC)
+
+  class Emitter(locationId: String, val eventLog: ActorRef) extends EventsourcedActor with ActorLogging {
+
+    override def id = s"${locationId}_Emitter"
+
+    override def onEvent = Actor.emptyBehavior
+
+    override def onCommand = {
+      case msg => persist(msg) {
+        case Success(_) =>
+        case Failure(ex) => log.error(ex, s"Error when persisting $msg in test")
+      }
+    }
+  }
+
+  def emitter(node: ReplicationNode, logName: String) =
+    node.system.actorOf(Props(new Emitter(node.id, node.logs(logName))))
+}
+
+class DeleteEventsSpec extends WordSpec with Matchers with ReplicationNodeRegistry with EventLogCleanupLeveldb {
+
+  import DeleteEventsSpec._
+
+  implicit val logFactory: String => Props = id => TestEventLog.props(id, batching = true)
+
+  private var ctr: Int = 0
+
+  override def beforeEach(): Unit =
+    ctr += 1
+
+  def config =
+    ReplicationConfig.create()
+
+  def nodeId(node: String): String =
+    s"${node}_${ctr}"
+
+  def node(nodeName: String, logNames: Set[String], port: Int, connections: Set[ReplicationConnection], customConfig: String = "", activate: Boolean = false): ReplicationNode =
+    register(new ReplicationNode(nodeId(nodeName), logNames, port, connections, customConfig = RecoverySpec.config + customConfig, activate = activate))
+
+  "Deleting events" must {
+    "not replay deleted events on restart" in {
+      val nodeA = newNodeA(Set(L1))
+      val emitterA = emitter(nodeA, L1)
+      val listenerA = nodeA.eventListener(L1)
+
+      (0 to 5).foreach(emitterA ! _)
+      listenerA.waitForMessage(5)
+
+      nodeA.endpoint.delete(L1, 3, Set.empty).await shouldBe 3
+
+      nodeA.terminate().await
+
+      val restartedA = newNodeA(Set(L1))
+      restartedA.eventListener(L1).expectMsgAllOf(3 to 5: _*)
+    }
+  }
+
+  "Conditionally deleting events" must {
+    "keep event available for corresponding remote log" in {
+      val nodeA = newNodeA(Set(L1), Set(connectedToB, connectedToC))
+      val nodeB = newNodeB(Set(L1), Set(connectedToA))
+      val nodeC = newNodeC(Set(L1), Set(connectedToA))
+      val emitterA = emitter(nodeA, L1)
+      val listenerA = nodeA.eventListener(L1)
+      val listenerB = nodeB.eventListener(L1)
+      val listenerC = nodeC.eventListener(L1)
+
+      (0 to 5).foreach(emitterA ! _)
+      listenerA.waitForMessage(5)
+
+      nodeA.endpoint.delete(L1, 3, Set(nodeB.endpoint.id, nodeC.endpoint.id)).await shouldBe 3
+
+      nodeA.endpoint.activate()
+      nodeB.endpoint.activate()
+      listenerB.expectMsgAllOf(0 to 5: _*)
+
+      nodeC.endpoint.activate()
+      listenerC.expectMsgAllOf(0 to 5: _*)
+    }
+  }
+
+  def newNodeA(logNames: Set[String], connections: Set[ReplicationConnection] = Set.empty) =
+    node("A", logNames, portA, connections)
+
+  def newNodeB(logNames: Set[String], connections: Set[ReplicationConnection] = Set.empty) =
+    node("B", logNames, portB, connections)
+
+  def newNodeC(logNames: Set[String], connections: Set[ReplicationConnection] = Set.empty) =
+    node("C", logNames, portC, connections)
+}

--- a/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/ReplicationConfig.scala
@@ -38,6 +38,7 @@ object ReplicationConfig {
          |eventuate.log.cassandra.index-update-limit = 3
          |eventuate.log.replication.batch-size-max = 3
          |eventuate.log.replication.retry-delay = 1s
+         |eventuate.log.leveldb.deletion-retry-delay = 1 ms
          |eventuate.log.replication.failure-detection-limit = 3s
        """.stripMargin)
 

--- a/src/it/scala/com/rbmhtechnology/eventuate/utilities/RestarterActor.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/utilities/RestarterActor.scala
@@ -1,0 +1,39 @@
+package com.rbmhtechnology.eventuate.utilities
+
+import akka.actor._
+import akka.pattern.ask
+import akka.util.Timeout
+
+class RestarterActor(props: Props, name: Option[String]) extends Actor {
+
+  import RestarterActor._
+
+  var child: ActorRef = newActor
+  var requester: ActorRef = _
+
+  override def receive = {
+    case Restart =>
+      requester = sender()
+      context.watch(child)
+      context.stop(child)
+    case Terminated(_) =>
+      child = newActor
+      requester ! child
+    case msg =>
+      child forward msg
+  }
+
+  private def newActor: ActorRef =
+    name.map(context.actorOf(props, _)).getOrElse(context.actorOf(props))
+}
+
+object RestarterActor {
+  case object Restart
+
+  implicit val timeout = Timeout(timeoutDuration)
+
+  def restartActor(restarterRef: ActorRef): ActorRef =
+    (restarterRef ? Restart).mapTo[ActorRef].await
+
+  def props(props: Props, name: Option[String] = None) = Props(new RestarterActor(props, name))
+}

--- a/src/it/scala/com/rbmhtechnology/eventuate/utilities/package.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/utilities/package.scala
@@ -13,8 +13,11 @@ import scala.concurrent._
 import scala.concurrent.duration._
 
 package object utilities {
+
+  val timeoutDuration = 10.seconds
+
   implicit class AwaitHelper[T](awaitable: Awaitable[T]) {
-    def await: T = Await.result(awaitable, 10.seconds)
+    def await: T = Await.result(awaitable, timeoutDuration)
   }
 
   def write(target: ReplicationTarget, events: Seq[String]): Unit = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -88,6 +88,13 @@ eventuate {
     # snapshot of the log's internal state (sequence number and merged vector
     # time) is written.
     state-snapshot-limit = 128
+
+    # Maximal number of events that are deleted in a single leveldb batch
+    deletion-batch-size-max = 100
+
+    # Delay between two tries to physically delete all requested events while keeping
+    # those that are not yet replicated.
+    deletion-retry-delay = 1 m
   }
 
   log.cassandra {

--- a/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
@@ -102,6 +102,29 @@ object EventsourcingProtocol {
   case class ReplayFailure(cause: Throwable, instanceId: Int)
 
   /**
+   * Instructs an event log to delete events with a sequence nr less or equal a given one.
+   * Deleted events are not replayed any more, however
+   * depending on the log implementation and `remoteLogIds` they might still be replicated.
+   *
+   * @param toSequenceNr All events with a less or equal sequence nr are not replayed any more.
+   * @param remoteLogIds A set of remote log ids that must have replicated events before they are allowed to be physically deleted.
+   */
+  case class Delete(toSequenceNr: Long, remoteLogIds: Set[String] = Set.empty)
+
+  /**
+   * Success reply after a [[Delete]]
+   *
+   * @param deletedTo The actually written deleted to marker. Minimum of [[Delete.toSequenceNr]] and
+   *                  the current sequence nr
+   */
+  case class DeleteSuccess(deletedTo: Long)
+
+  /**
+   * Failure reply after a [[Delete]]
+   */
+  case class DeleteFailure(cause: Throwable)
+
+  /**
    * Instructs an event log to save the given `snapshot`.
    */
   case class SaveSnapshot(snapshot: Snapshot, initiator: ActorRef, requestor: ActorRef, instanceId: Int)

--- a/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
@@ -95,7 +95,9 @@ object ReplicationProtocol {
   case class GetEventLogClockSuccess(clock: EventLogClock)
 
   /**
-   * Requests all replication progresses from a log.
+   * Requests all local replication progresses from a log.
+   * The local replication progress is the sequence nr in the remote log up to which
+   * the local log has replicated all events from the remote log
    */
   case object GetReplicationProgresses
 
@@ -110,7 +112,8 @@ object ReplicationProtocol {
   case class GetReplicationProgressesFailure(cause: Throwable)
 
   /**
-   * Requests the replication progress for given `sourceLogId` from a target log.
+   * Requests the local replication progress for given `sourceLogId` from a target log.
+   * @see GetReplicationProgresses
    */
   case class GetReplicationProgress(sourceLogId: String)
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraDeletedToStore.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraDeletedToStore.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.lang.{ Long => JLong }
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+private[eventuate] class CassandraDeletedToStore(cassandra: Cassandra, logId: String) {
+
+  def writeDeletedToSync(deletedTo: Long)(implicit executor: ExecutionContext): Unit =
+    cassandra.session.execute(cassandra.preparedWriteDeletedToStatement.bind(logId, deletedTo: JLong))
+
+  def readDeletedToAsync(implicit executor: ExecutionContext): Future[Long] = {
+    cassandra.session.executeAsync(cassandra.preparedReadDeletedToStatement.bind(logId)).map { resultSet =>
+      if (resultSet.isExhausted) 0L else resultSet.one().getLong("deleted_to")
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
@@ -76,6 +76,8 @@ class CassandraEventLogSettings(config: Config) extends EventLogSettings {
   val initRetryDelay: FiniteDuration =
     config.getDuration("eventuate.log.cassandra.init-retry-delay", TimeUnit.MILLISECONDS).millis
 
+  val deletionRetryDelay: FiniteDuration = 10.minutes
+
   val initialConnectRetryMax: Int =
     config.getInt("eventuate.log.cassandra.initial-connect-retry-max")
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
@@ -128,3 +128,24 @@ private[eventuate] trait CassandraReplicationProgressStatements extends Cassandr
 
   def replicationProgressTable = table("rp")
 }
+
+private[eventuate] trait CassandraDeletedToStatements extends CassandraStatements {
+  def createDeletedToTableStatement = s"""
+      CREATE TABLE IF NOT EXISTS ${deletedToTable} (
+        log_id text,
+        deleted_to bigint,
+        PRIMARY KEY (log_id))
+    """
+
+  def writeDeletedToStatement: String = s"""
+      INSERT INTO ${deletedToTable} (log_id, deleted_to)
+      VALUES (?, ?)
+    """
+
+  def readDeletedToStatement: String = s"""
+      SELECT deleted_to FROM ${deletedToTable}
+      WHERE log_id = ?
+    """
+
+  def deletedToTable = table("del")
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbDeletionActor.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbDeletionActor.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.leveldb
+
+import java.io.Closeable
+
+import akka.actor.Actor
+import akka.actor.PoisonPill
+import akka.actor.Props
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog._
+
+import org.iq80.leveldb.DB
+import org.iq80.leveldb.ReadOptions
+import org.iq80.leveldb.WriteOptions
+
+import scala.annotation.tailrec
+import scala.concurrent.Promise
+
+private object LeveldbDeletionActor {
+  case object DeleteBatch
+
+  def props(leveldb: DB, leveldbReadOptions: ReadOptions, leveldbWriteOptions: WriteOptions, batchSize: Int, toSequenceNr: Long, promise: Promise[Unit]): Props =
+    Props(new LeveldbDeletionActor(leveldb, leveldbReadOptions, leveldbWriteOptions, batchSize, toSequenceNr, promise))
+}
+
+class LeveldbDeletionActor(
+  val leveldb: DB,
+  val leveldbReadOptions: ReadOptions,
+  val leveldbWriteOptions: WriteOptions,
+  batchSize: Int,
+  toSequenceNr: Long,
+  promise: Promise[Unit])
+  extends Actor with WithBatch {
+
+  import LeveldbDeletionActor._
+
+  val eventKeyIterator: CloseableIterator[EventKey] = newEventKeyIterator
+
+  override def preStart() = self ! DeleteBatch
+
+  override def postStop() = eventKeyIterator.close()
+
+  override def receive = {
+    case DeleteBatch =>
+      withBatch { batch =>
+        eventKeyIterator.take(batchSize).foreach { eventKey =>
+          batch.delete(eventKeyBytes(eventKey.classifier, eventKey.sequenceNr))
+        }
+      }
+      if (eventKeyIterator.hasNext) {
+        self ! DeleteBatch
+      } else {
+        promise.success(())
+        self ! PoisonPill
+      }
+  }
+
+  private def newEventKeyIterator: CloseableIterator[EventKey] = {
+    new Iterator[EventKey] with Closeable {
+      val iterator = leveldb.iterator(leveldbReadOptions.snapshot(leveldb.getSnapshot))
+      iterator.seek(eventKeyBytes(EventKey.DefaultClassifier, 1L))
+
+      @tailrec
+      override def hasNext: Boolean = {
+        val key = eventKey(iterator.peekNext().getKey)
+        key != eventKeyEnd &&
+          (key.sequenceNr <= toSequenceNr || {
+            iterator.seek(eventKeyBytes(key.classifier + 1, 1L))
+            hasNext
+          })
+      }
+
+      override def next() = eventKey(iterator.next().getKey)
+      override def close() = {
+        iterator.close()
+        leveldbReadOptions.snapshot().close()
+      }
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbDeletionMetadataStore.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/leveldb/LeveldbDeletionMetadataStore.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.leveldb
+
+import java.nio.ByteBuffer
+
+import com.rbmhtechnology.eventuate.log.DeletionMetadata
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog.WithBatch
+import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog.longBytes
+import org.iq80.leveldb.DB
+import org.iq80.leveldb.WriteOptions
+
+class LeveldbDeletionMetadataStore(val leveldb: DB, val leveldbWriteOptions: WriteOptions, classifier: Int) extends WithBatch {
+  private val DeletedToSequenceNrKey: Int = 1
+  private val RemoteLogIdsKey: Int = 2
+
+  private val StringSetSeparatorChar = '\u0000'
+
+  def writeDeletionMetadata(info: DeletionMetadata): Unit = withBatch { batch =>
+    batch.put(idKeyBytes(DeletedToSequenceNrKey), longBytes(info.toSequenceNr))
+    batch.put(idKeyBytes(RemoteLogIdsKey), stringSetBytes(info.remoteLogIds))
+  }
+
+  def readDeletionMetadata(): DeletionMetadata = {
+    val toSequenceNr = longFromBytes(leveldb.get(idKeyBytes(DeletedToSequenceNrKey)))
+    val remoteLogIds = stringSetFromBytes(leveldb.get(idKeyBytes(RemoteLogIdsKey)))
+    DeletionMetadata(toSequenceNr, remoteLogIds)
+  }
+
+  private def idKeyBytes(key: Int): Array[Byte] = {
+    val bb = ByteBuffer.allocate(8)
+    bb.putInt(classifier)
+    bb.putInt(key)
+    bb.array
+  }
+
+  private def longFromBytes(longBytes: Array[Byte]): Long =
+    if (longBytes == null) 0 else LeveldbEventLog.longFromBytes(longBytes)
+
+  private def stringSetBytes(set: Set[String]): Array[Byte] =
+    set.mkString(StringSetSeparatorChar.toString).getBytes("UTF-8")
+
+  private def stringSetFromBytes(setBytes: Array[Byte]): Set[String] =
+    if (setBytes == null || setBytes.length == 0)
+      Set.empty
+    else
+      new String(setBytes, "UTF-8").split(StringSetSeparatorChar).toSet
+}

--- a/src/sphinx/code/EventLogDoc.scala
+++ b/src/sphinx/code/EventLogDoc.scala
@@ -92,6 +92,18 @@ trait ReplicationEndpointDoc {
   }
   //#
 
+  //#event-deletion-1
+  // logically delete all events from log L1 with a sequence number <= 100
+  // defer physical deletion until they are replicated to the given endpoints
+  val logicallyDeleted: Future[Long] =
+    endpoint.delete("L1", 100L, Set("remoteEndpointId1", "remoteEndpointId2"))
+
+  logicallyDeleted onComplete {
+    case Success(sequenceNr) => // events up to sequenceNr are logically deleted
+    case Failure(e) => // deletion failed
+  }
+  //#
+
 }
 
 trait ReplicationFilterDoc {

--- a/src/sphinx/reference/event-log.rst
+++ b/src/sphinx/reference/event-log.rst
@@ -247,7 +247,29 @@ Disaster recovery also deletes invalid snapshots, in case they survived the disa
 A complete reference of ``eventuate.disaster-recovery.*`` configuration options is given in section :ref:`configuration`. The example application also implements :ref:`example-disaster-recovery`.
 
 .. note::
-   Installing a storage backup is a separate administrative task that is not covered by running ``recover()``. 
+   Installing a storage backup is a separate administrative task that is not covered by running ``recover()``.
+
+Deleting events
+~~~~~~~~~~~~~~~
+
+As outlined in the :ref:`introduction` an event log is a continuously growing store of immutable facts. Depending on the implementation of the application not all events are necessarily required to recover application state after an application or actor restart. For example, if the application writes sanpshots only those events that occurred after the snapshot need to be available. But even without snapshots there can be application-specific boundary conditions that allow an application to recover its state from a certain sequence number on. To keep a store from growing indefinitely in these cases a ``ReplicationEndpoint`` allows to delete events up to a given sequence number from a local log. Deletion of events actually differentiates between:
+
+- Logical deletion of events: Events that are logically deleted are not replayed in case of an actor restart. However they are still available for replication to event logs of connected ``ReplicationEndpoint``\ s. All storage backends support logical deletion of events.
+- Physical deletion of events: Depending on the storage backend logically deleted events are eventually physically deleted. Physical deleted events are of course not available any more for local replay or replication. Physical deletion is currently only supported by the LevelDB backend.
+
+Eventuate is a toolkit for implementing distributed applications. While an application can very well decide, if it needs certain events from the event log to recover its state, it is much less clear if these events might be needed in the future for replication to logs of other ``ReplicationEndpoint``\ s. Eventuate can defer physical deletion of events until they are replicated to known ``ReplicationEndpoint``\ s. However once they are deleted it might get impossible to add new ``ReplicationEndpoint``\ s or support disaster recovery of an existing ``ReplicationEndpoint``. Therefore deleting events physically from a local log must be used with great care. In a replication network a leaf-``ReplicationEndpoint`` that connects to a single ``ReplicationEndpoint`` maybe even through a ``ReplicationFilter`` is for example a candidate where physical deletion cause small risk as this endpoint is typically not suitable for further connections.
+
+Considering this deletion is invoked through the method ``delete`` of a ``ReplicationEndpoint``
+
+.. includecode:: ../code/EventLogDoc.scala
+   :snippet: event-deletion-1
+
+This method returns the sequence number until which events are logically deleted. The returned number can differ from the requested one (here ``100L``), if
+
+- the log's current sequence number is smaller than the requested number. In this case the current sequence number is returned.
+- there was a previous successful deletion request with a higher sequence number. In this case that number is returned.
+
+Depending on the storage backend this call also triggers physical deletion of events in a reliable background process that survives restarts. To defer deletion of non-replicated events, the third parameter takes a set of ``ReplicationEndpoint`` ids. Events are not deleted until they are replicated to all specified endpoints. If an empty set is specified asynchronous deletion is triggered immediately.
 
 .. _Cassandra: http://cassandra.apache.org/
 .. _Getting Started: https://wiki.apache.org/cassandra/GettingStarted


### PR DESCRIPTION
- leveldb log supports physical deletion
- cassandra only logical
- physical deletion can be deferred until events
  are replicated
- ReplicationEndpoint has new delete-api