### PR TITLE
Circuit breaker for Cassandra event log and chaos test bug fix

### DIFF
--- a/.travis/test-it.sh
+++ b/.travis/test-it.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
 sbt $1 "it:testOnly \
-  com.rbmhtechnology.eventuate.RecoverySpec \
-  com.rbmhtechnology.eventuate.DeleteEventsSpec \
   com.rbmhtechnology.eventuate.crdt.* \
   com.rbmhtechnology.eventuate.serializer.* \
-  com.rbmhtechnology.eventuate.snapshot.filesystem.* \
+  com.rbmhtechnology.eventuate.snapshot.filesystem.*
   *Leveldb"

--- a/src/it/scala/com/rbmhtechnology/eventuate/DeleteEventsSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/DeleteEventsSpec.scala
@@ -16,11 +16,8 @@
 
 package com.rbmhtechnology.eventuate
 
-import akka.actor.Actor
-import akka.actor.ActorLogging
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.Props
+import akka.actor._
+
 import com.rbmhtechnology.eventuate.ReplicationIntegrationSpec.replicationConnection
 import com.rbmhtechnology.eventuate.log.EventLogCleanupLeveldb
 import com.rbmhtechnology.eventuate.log.EventLogLifecycleLeveldb.TestEventLog
@@ -32,7 +29,7 @@ import org.scalatest.WordSpec
 import scala.util.Failure
 import scala.util.Success
 
-object DeleteEventsSpec {
+object DeleteEventsSpecLeveldb {
   val L1 = "L1"
 
   val portA = 2552
@@ -62,9 +59,8 @@ object DeleteEventsSpec {
     node.system.actorOf(Props(new Emitter(node.id, node.logs(logName))))
 }
 
-class DeleteEventsSpec extends WordSpec with Matchers with ReplicationNodeRegistry with EventLogCleanupLeveldb {
-
-  import DeleteEventsSpec._
+class DeleteEventsSpecLeveldb extends WordSpec with Matchers with ReplicationNodeRegistry with EventLogCleanupLeveldb {
+  import DeleteEventsSpecLeveldb._
 
   implicit val logFactory: String => Props = id => TestEventLog.props(id, batching = true)
 
@@ -80,7 +76,7 @@ class DeleteEventsSpec extends WordSpec with Matchers with ReplicationNodeRegist
     s"${node}_${ctr}"
 
   def node(nodeName: String, logNames: Set[String], port: Int, connections: Set[ReplicationConnection], customConfig: String = "", activate: Boolean = false): ReplicationNode =
-    register(new ReplicationNode(nodeId(nodeName), logNames, port, connections, customConfig = RecoverySpec.config + customConfig, activate = activate))
+    register(new ReplicationNode(nodeId(nodeName), logNames, port, connections, customConfig = RecoverySpecLeveldb.config + customConfig, activate = activate))
 
   "Deleting events" must {
     "not replay deleted events on restart" in {

--- a/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/RecoverySpec.scala
@@ -32,7 +32,7 @@ import org.scalatest._
 
 import scala.concurrent.duration._
 
-object RecoverySpec {
+object RecoverySpecLeveldb {
   class ConvergenceView(val id: String, val eventLog: ActorRef, expectedSize: Int, probe: ActorRef) extends EventsourcedView {
     var state: Set[String] = Set()
 
@@ -65,9 +65,9 @@ object RecoverySpec {
   }
 }
 
-class RecoverySpec extends WordSpec with Matchers with ReplicationNodeRegistry with EventLogCleanupLeveldb {
+class RecoverySpecLeveldb extends WordSpec with Matchers with ReplicationNodeRegistry with EventLogCleanupLeveldb {
   import ReplicationIntegrationSpec.replicationConnection
-  import RecoverySpec._
+  import RecoverySpecLeveldb._
 
   implicit val logFactory: String => Props = id => EventLogLifecycleLeveldb.TestEventLog.props(id, batching = true)
 
@@ -83,7 +83,7 @@ class RecoverySpec extends WordSpec with Matchers with ReplicationNodeRegistry w
     s"${node}_${ctr}"
 
   def node(nodeName: String, logNames: Set[String], port: Int, connections: Set[ReplicationConnection], customConfig: String = "", activate: Boolean = false): ReplicationNode =
-    register(new ReplicationNode(nodeId(nodeName), logNames, port, connections, customConfig = RecoverySpec.config + customConfig, activate = activate))
+    register(new ReplicationNode(nodeId(nodeName), logNames, port, connections, customConfig = RecoverySpecLeveldb.config + customConfig, activate = activate))
 
   def assertConvergence(expected: Set[String], nodes: ReplicationNode *): Unit = {
     val probes = nodes.map { node =>

--- a/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTChaosSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTChaosSpec.scala
@@ -164,6 +164,6 @@ class CRDTChaosSpecCassandra  extends CRDTChaosSpec with EventLogCleanupCassandr
 
   def logProps(logId: String, batching: Boolean = true): Props = {
     val logProps = Props(new TestEventLog(logId)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
-    if (batching) Props(new BatchingLayer(logProps)) else logProps
+    Props(new CircuitBreaker(logProps, batching))
   }
 }

--- a/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpec.scala
@@ -8,7 +8,7 @@ import com.rbmhtechnology.eventuate.utilities._
 
 import org.scalatest._
 
-class CRDTServiceSpec  extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with EventLogLifecycleLeveldb {
+class CRDTServiceSpecLeveldb extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with EventLogLifecycleLeveldb {
   "A CRDTService" must {
     "manage multiple CRDTs identified by name" in {
       val service = new CounterService[Int]("a", log)

--- a/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpec.scala
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log
+
+import java.util.concurrent.CountDownLatch
+
+import akka.actor._
+import akka.testkit._
+import akka.pattern.ask
+import akka.util.Timeout
+
+import com.rbmhtechnology.eventuate._
+import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.rbmhtechnology.eventuate.log.cassandra._
+import com.rbmhtechnology.eventuate.utilities.AwaitHelper
+import com.typesafe.config._
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import org.scalatest._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Seconds, Span}
+
+import scala.collection.immutable.Seq
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util._
+import scala.util.control.NoStackTrace
+
+object CircuitBreakerIntregrationSpecCassandra {
+  val config: Config = ConfigFactory.parseString(
+    """
+      |akka.loglevel = "ERROR"
+      |akka.test.single-expect-default = 10s
+      |
+      |eventuate.log.circuit-breaker.open-after-retries = 2
+      |eventuate.log.cassandra.write-retry-max = 3
+      |eventuate.log.cassandra.default-port = 9142
+      |eventuate.log.cassandra.index-update-limit = 3
+      |eventuate.log.cassandra.init-retry-delay = 1s
+      |eventuate.snapshot.filesystem.dir = target/test-snapshot
+    """.stripMargin)
+
+  case class TestFailureSpec(
+    failingAttempts: Int,
+    appLatch: CountDownLatch,
+    logLatch: CountDownLatch)
+
+  class TestEventLog(id: String, failureSpec: TestFailureSpec) extends CassandraEventLog(id) {
+    override private[eventuate] def createEventLogStore(cassandra: Cassandra, logId: String) =
+      new TestEventLogStore(cassandra, logId, failureSpec)
+  }
+
+  class TestEventLogStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraEventLogStore(cassandra, logId) {
+    import failureSpec._
+
+    var numAttempts = 0
+
+    override def write(events: Seq[DurableEvent], partition: Long): Unit =
+      if (numAttempts < failingAttempts && events.map(_.payload).contains("timeout")) {
+        numAttempts += 1
+        appLatch.countDown()
+        throw new TimeoutException("test") with NoStackTrace
+      } else if (numAttempts == failingAttempts) {
+        logLatch.await()
+      } else {
+        super.write(events, partition)
+      }
+  }
+
+  class TestActor(val id: String, val eventLog: ActorRef, override val stateSync: Boolean) extends EventsourcedActor {
+    override val aggregateId = Some(id)
+
+    override def onCommand = {
+      case s: String =>
+        persist(s) {
+          case Success(_) => sender() ! s
+          case Failure(e) => sender() ! Status.Failure(e)
+        }
+    }
+
+    override def onEvent = {
+      case e: String =>
+    }
+  }
+}
+
+class CircuitBreakerIntregrationSpecCassandra extends TestKit(ActorSystem("test", CircuitBreakerIntregrationSpecCassandra.config))
+  with WordSpecLike with Matchers with BeforeAndAfterEach with EventLogCleanupCassandra with Eventually {
+
+  import CircuitBreakerIntregrationSpecCassandra._
+  import system.dispatcher
+
+  implicit val implicitTimeout = Timeout(10.seconds)
+
+  var log: ActorRef = _
+  var logCtr: Int = 0
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    logCtr += 1
+  }
+
+  override def afterEach(): Unit = {
+    system.stop(log)
+    super.afterEach()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    EmbeddedCassandraServerHelper.startEmbeddedCassandra(60000)
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  override implicit def patienceConfig =
+    PatienceConfig(Span(10, Seconds), Span(100, Millis))
+
+  def config: Config =
+    system.settings.config
+
+  def logId: String =
+    logCtr.toString
+
+  def logProps(logId: String, failureSpec: TestFailureSpec): Props = {
+    val logProps = Props(new TestEventLog(logId, failureSpec)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
+    Props(new CircuitBreaker(logProps, batching = true))
+  }
+
+  def createLog(failureSpec: TestFailureSpec = this.failureSpec(-1)): Unit = {
+    log = system.actorOf(logProps(logId, failureSpec))
+  }
+
+  def failureSpec(failingAttempts: Int): TestFailureSpec =
+    TestFailureSpec(failingAttempts, new CountDownLatch(failingAttempts max 0), new CountDownLatch(1))
+
+  "A circuit breaker" must {
+    "be initially closed" in {
+      createLog()
+
+      write("a", 1L).await should be(1)
+      write("b", 2L).await should be(1)
+    }
+    "remain closed if retry count < 2" in {
+      val spec = failureSpec(2)
+      createLog(spec)
+
+      val op1 = write("timeout", 1L)
+      spec.appLatch.await()
+      val op2 = write("b", 2L)
+      spec.logLatch.countDown()
+
+      op1.await should be(1)
+      op2.await should be(1)
+    }
+    "open if retry count == 2 and close again after subsequent successful retry" in {
+      val spec = failureSpec(3)
+      createLog(spec)
+
+      write("timeout", 1L)
+      spec.appLatch.await()
+      assertUnavailable()
+      spec.logLatch.countDown()
+
+      eventually {
+        write("b", 2L).await should be(1)
+      }
+    }
+    "stop if the underlying log stops" in {
+      val probe = TestProbe()
+      val spec = failureSpec(10)
+      createLog(spec)
+
+      write("timeout", 1L)
+
+      probe.watch(log)
+      probe.expectTerminated(log)
+    }
+  }
+
+  "A circuit breaker" when {
+    "open" must {
+      "reply with an UnavailableException failure to an event-sourced actor with stateSync = false in any case" in {
+        implicit val implicitTimeout = Timeout(10.seconds)
+        val spec = failureSpec(3)
+        createLog(spec)
+
+        val actor1 = system.actorOf(Props(new TestActor("1", log, stateSync = false)))
+        //val actor2 = system.actorOf(Props(new TestActor("2", log, stateSync = true)))
+
+        request(actor1, "timeout")
+        spec.appLatch.await()
+
+        eventually {
+          intercept[UnavailableException] { request(actor1, "a").await }
+        }
+
+        spec.logLatch.countDown()
+
+        eventually {
+          request(actor1, "b").await should be("b")
+        }
+      }
+      "reply with UnavailableException failure to an event-sourced actor with stateSync = true if that actor was idle at the time of opening" in {
+        implicit val implicitTimeout = Timeout(10.seconds)
+        val spec = failureSpec(3)
+        createLog(spec)
+
+        val actor1 = system.actorOf(Props(new TestActor("1", log, stateSync = false)))
+        val actor2 = system.actorOf(Props(new TestActor("2", log, stateSync = true)))
+
+        request(actor1, "timeout")
+        spec.appLatch.await()
+
+        eventually {
+          intercept[UnavailableException] { request(actor1, "a").await }
+        }
+
+        // The circuit breaker opened when actor2 (stateSync = true) was
+        // idle. A later request from that actor will therefore receive
+        // an UnavailableException failure reply.
+        intercept[UnavailableException] { request(actor2, "a").await }
+
+        spec.logLatch.countDown()
+
+        eventually {
+          request(actor1, "b").await should be("b")
+          request(actor2, "b").await should be("b")
+        }
+      }
+    }
+  }
+
+  def assertUnavailable(): Unit = {
+    val w = ReplicationWrite(Seq(), "source", 0L, VectorTime.Zero)
+    eventually {
+      intercept[UnavailableException] { log.ask(w).await }
+    }
+  }
+
+  def write(payload: Any, sequenceNr: Long)(implicit executor: ExecutionContext): Future[Int] = {
+    val e = DurableEvent(payload, "emitter", vectorTimestamp = VectorTime("source" -> sequenceNr))
+    val w = ReplicationWrite(Seq(e), "source", sequenceNr, VectorTime.Zero)
+
+    log.ask(w) flatMap {
+      case s: ReplicationWriteSuccess => Future.successful(s.num)
+      case f: ReplicationWriteFailure => Future.failed(f.cause)
+    }
+  }
+
+  def request(actor: ActorRef, command: String): Future[String] =
+    actor.ask(command).mapTo[String]
+}

--- a/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
@@ -30,7 +30,7 @@ import com.rbmhtechnology.eventuate.log.EventLogLifecycle._
 import com.rbmhtechnology.eventuate.log.EventLogLifecycleCassandra.TestFailureSpec
 import com.rbmhtechnology.eventuate.log.cassandra._
 import com.rbmhtechnology.eventuate.utilities.RestarterActor.restartActor
-import com.rbmhtechnology.eventuate.utilities.{AwaitHelper, timeoutDuration}
+import com.rbmhtechnology.eventuate.utilities._
 
 import com.typesafe.config.{ConfigFactory, Config}
 
@@ -51,8 +51,6 @@ object EventLogSpec {
       |akka.loglevel = "ERROR"
       |akka.test.single-expect-default = 10s
       |
-      |eventuate.snapshot.filesystem.dir = target/test-snapshot
-      |
       |eventuate.log.leveldb.dir = target/test-log
       |eventuate.log.leveldb.index-update-limit = 6
       |eventuate.log.leveldb.deletion-batch-size = 2
@@ -60,6 +58,7 @@ object EventLogSpec {
       |eventuate.log.cassandra.default-port = 9142
       |eventuate.log.cassandra.index-update-limit = 3
       |eventuate.log.cassandra.init-retry-delay = 1s
+      |eventuate.snapshot.filesystem.dir = target/test-snapshot
     """.stripMargin)
 
   val emitterIdA = "A"
@@ -469,7 +468,7 @@ abstract class EventLogSpec extends TestKit(ActorSystem("test", EventLogSpec.con
     "replication-read events from a custom position with a batch size limit" in {
       generateEmittedEvents()
       log.tell(ReplicationRead(2, 1, NoFilter, UndefinedLogId, dl, VectorTime()), replyToProbe.ref)
-      replyToProbe.expectMsg(ReplicationReadSuccess(generatedEmittedEvents.drop(1).take(1), 2, UndefinedLogId, VectorTime(logId -> 3L)))
+      replyToProbe.expectMsg(ReplicationReadSuccess(generatedEmittedEvents.slice(1, 2), 2, UndefinedLogId, VectorTime(logId -> 3L)))
     }
     "replication-read events with exclusion" in {
       generateEmittedEvents()

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -28,8 +28,8 @@ eventuate {
     read-timeout = 10s
 
     # Timeout for write operations to a local event log. These are batch
-    # event writes made by event-sourced actors and processors as well
-    # as batch event writes made by replicators.
+    # event writes made by event-sourced processors and replicators. This
+    # timeout does not apply to event-sourced actor writes.
     write-timeout = 10s
 
     # Target batch size for writing events. It is used by the batching layer
@@ -46,6 +46,11 @@ eventuate {
     # resumed automatically after the replayed event batch has been handled
     # (= replay backpressure).
     replay-batch-size = 4096
+  }
+
+  log.circuit-breaker {
+    # Number of write retries after which the circuit breaker should be opened.
+    open-after-retries = 2
   }
 
   log.replication {
@@ -131,6 +136,10 @@ eventuate {
 
     # Replication factor to use when creating the keyspace.
     replication-factor = 1
+
+    # Maximum number of times a failed write should be retried until the event
+    # log actor gives up and stops itself.
+    write-retry-max = 65536
 
     # Write consistency level
     write-consistency = "QUORUM"

--- a/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
@@ -192,7 +192,7 @@ object ReplicationProtocol {
    * @param num Number of events actually replicated.
    * @param sourceLogId Id of the log the written events were replicated from.
    * @param storedReplicationProgress Last source log read position stored in the target log.
-   * @param currentTargetVersionVector [[EventLogClock.versionVector]] of the target log after the events were written
+   * @param currentTargetVersionVector [[log.EventLogClock.versionVector Version vector]] of the target log after the events were written
    */
   case class ReplicationWriteSuccess(num: Int, sourceLogId: String, storedReplicationProgress: Long, currentTargetVersionVector: VectorTime)
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/UnavailableException.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/UnavailableException.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+/**
+ * Indicates that an event log or event-sourced actor is currently unavailable for serving requests.
+ */
+class UnavailableException extends RuntimeException

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/CircuitBreaker.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/CircuitBreaker.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log
+
+import akka.actor._
+
+import com.rbmhtechnology.eventuate.EventsourcingProtocol._
+import com.rbmhtechnology.eventuate.UnavailableException
+import com.typesafe.config.Config
+
+private class CircuitBreakerSettings(config: Config) {
+  val openAfterRetries =
+    config.getInt("eventuate.log.circuit-breaker.open-after-retries")
+}
+
+/**
+ * A wrapper that can protect [[EventLog]] implementations from being overloaded while they are retrying to
+ * serve a write request. If the circuit breaker is closed, it forwards all requests to the underlying event
+ * log. If it is open, it replies with a failure message to the requestor. The circuit breaker can be opened
+ * by sending it `ServiceFailure` messages with a `retry` value greater than or equal to the configuration
+ * parameter `eventuate.log.circuit-breaker.open-after-retries`. It can be closed again by sending it a
+ * `ServiceNormal` or `ServiceInitialized` message. These messages are usually sent by [[EventLog]]
+ * implementations and not by applications.
+ *
+ * @see [[EventLogSPI.write]]
+ */
+class CircuitBreaker(logProps: Props, batching: Boolean) extends Actor {
+  import CircuitBreaker._
+
+  private val settings =
+    new CircuitBreakerSettings(context.system.settings.config)
+
+  private val eventLog: ActorRef =
+    context.watch(createLog)
+
+  private val closed: Receive = {
+    case ServiceInitialized | ServiceNormal =>
+    // normal operation
+    case ServiceFailed(retry) =>
+      if (retry >= settings.openAfterRetries) context.become(open)
+    case Terminated(_) =>
+      context.stop(self)
+    case msg =>
+      eventLog forward msg
+  }
+
+  private val open: Receive = {
+    case ServiceInitialized | ServiceNormal =>
+      context.become(closed)
+    case ServiceFailed(retry) =>
+    // failure persists
+    case Terminated(_) =>
+      context.stop(self)
+    case Write(events, initiator, replyTo, cid, iid) =>
+      // Write requests are not made via ask
+      replyTo.tell(WriteFailure(events, Exception, cid, iid), initiator)
+    case msg =>
+      // All other requests are made via ask
+      sender() ! Status.Failure(Exception)
+  }
+
+  def receive =
+    closed
+
+  private def createLog(): ActorRef =
+    if (batching) context.actorOf(Props(new BatchingLayer(logProps))) else context.actorOf(logProps)
+}
+
+private object CircuitBreaker {
+  /**
+   * Default [[UnavailableException]] instance.
+   */
+  val Exception = new UnavailableException
+
+  /**
+   * An event that controls [[CircuitBreaker]] state.
+   */
+  sealed trait ServiceEvent
+
+  /**
+   * Sent by an event log to indicate that it has been successfully initialized.
+   */
+  case object ServiceInitialized extends ServiceEvent
+
+  /**
+   * Sent by an event log to indicate that it has successfully written an event batch.
+   */
+  case object ServiceNormal extends ServiceEvent
+
+  /**
+   * Sent by an event log to indicate that it failed to write an event batch. The current
+   * retry count is given by the `retry` parameter.
+   */
+  case class ServiceFailed(retry: Int) extends ServiceEvent
+
+}
+

--- a/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
@@ -56,6 +56,9 @@ class CassandraEventLogSettings(config: Config) extends EventLogSettings {
   val writeConsistency: ConsistencyLevel =
     ConsistencyLevel.valueOf(config.getString("eventuate.log.cassandra.write-consistency"))
 
+  val writeRetryMax: Int =
+    config.getInt("eventuate.log.cassandra.write-retry-max")
+
   val defaultPort: Int =
     config.getInt("eventuate.log.cassandra.default-port")
 

--- a/src/sphinx/current-limitations.rst
+++ b/src/sphinx/current-limitations.rst
@@ -12,5 +12,5 @@ The following is a list of known limitations that are going to be addressed in f
 
 - No performance optimizations have been made yet.
 
-.. _Akka Cluster: http://doc.akka.io/docs/akka/2.3.9/scala/cluster-usage.html
+.. _Akka Cluster: http://doc.akka.io/docs/akka/2.4.1/scala/cluster-usage.html
 .. _let us know: https://groups.google.com/forum/#!forum/eventuate

--- a/src/sphinx/reference/event-log.rst
+++ b/src/sphinx/reference/event-log.rst
@@ -276,8 +276,8 @@ Depending on the storage backend, this call also triggers physical deletion of e
 .. _Getting Started: https://wiki.apache.org/cassandra/GettingStarted
 .. _cassandra-unit: https://github.com/jsevellec/cassandra-unit/wiki
 .. _LevelDB: https://github.com/google/leveldb
-.. _Akka Remoting: http://doc.akka.io/docs/akka/2.3.9/scala/remoting.html
-.. _event stream: http://doc.akka.io/docs/akka/2.3.9/scala/event-bus.html#event-stream
+.. _Akka Remoting: http://doc.akka.io/docs/akka/2.4.1/scala/remoting.html
+.. _event stream: http://doc.akka.io/docs/akka/2.4.1/scala/event-bus.html#event-stream
 .. _Chaos testing with Docker and Cassandra on Mac OS X: http://rbmhtechnology.github.io/chaos-testing-with-docker-and-cassandra/
 
 .. _EventsourcingProtocol: ../latest/api/index.html#com.rbmhtechnology.eventuate.EventsourcingProtocol$

--- a/src/sphinx/user-guide.rst
+++ b/src/sphinx/user-guide.rst
@@ -291,7 +291,7 @@ In a more real-world example, there would be several actors of different type co
 .. _vector clock update rules: http://en.wikipedia.org/wiki/Vector_clock
 .. _version vector update rules: http://en.wikipedia.org/wiki/Version_vector
 .. _Lamport timestamps: http://en.wikipedia.org/wiki/Lamport_timestamps
-.. _multi node testkit: http://doc.akka.io/docs/akka/2.3.9/dev/multi-node-testing.html
+.. _multi node testkit: http://doc.akka.io/docs/akka/2.4.1/dev/multi-node-testing.html
 .. _ReplicatedOrSetSpec: https://github.com/RBMHTechnology/eventuate/blob/master/src/multi-jvm/scala/com/rbmhtechnology/eventuate/crdt/ReplicatedORSetSpec.scala
 .. _CRDT sources: https://github.com/RBMHTechnology/eventuate/tree/master/src/main/scala/com/rbmhtechnology/eventuate/crdt
 .. _A comprehensive study of Convergent and Commutative Replicated Data Types: http://hal.upmc.fr/file/index/docid/555588/filename/techreport.pdf

--- a/src/test/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log
+
+import akka.actor._
+import akka.pattern.ask
+import akka.testkit._
+import akka.util.Timeout
+
+import com.rbmhtechnology.eventuate._
+import com.rbmhtechnology.eventuate.EventsourcingProtocol._
+import com.typesafe.config.ConfigFactory
+
+import org.scalatest._
+
+import scala.collection.immutable.Seq
+import scala.concurrent._
+import scala.concurrent.duration._
+
+object CircuitBreakerSpec {
+  implicit val timeout = Timeout(3.seconds)
+
+  implicit class AwaitHelper[T](awaitable: Awaitable[T]) {
+    def await: T = Await.result(awaitable, timeout.duration)
+  }
+
+  class TestLog extends Actor {
+    def receive = {
+      case msg => sender() ! s"re-$msg"
+    }
+  }
+}
+
+class CircuitBreakerSpec extends TestKit(ActorSystem("test", ConfigFactory.parseString("eventuate.log.circuit-breaker.open-after-retries = 1")))
+  with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+
+  import CircuitBreakerSpec._
+  import CircuitBreaker._
+
+  private var breaker: ActorRef = _
+  private var probe: TestProbe = _
+
+  override def afterAll(): Unit =
+    TestKit.shutdownActorSystem(system)
+
+  override def beforeEach(): Unit = {
+    probe = TestProbe()
+    breaker = system.actorOf(Props(new CircuitBreaker(Props(new TestLog), batching = false)))
+  }
+
+  "A circuit breaker" must {
+    "be closed after initialization" in {
+      breaker.ask("a").await should be("re-a")
+    }
+    "be closed after initial failure" in {
+      breaker ! ServiceFailed(0)
+      breaker.ask("a").await should be("re-a")
+    }
+    "open after first failed retry" in {
+      breaker ! ServiceFailed(1)
+      intercept[UnavailableException] {
+        breaker.ask("a").await
+      }
+    }
+    "close again after service success" in {
+      breaker ! ServiceFailed(1)
+      intercept[UnavailableException] {
+        breaker.ask("a").await
+      }
+      breaker ! ServiceNormal
+      breaker.ask("a").await should be("re-a")
+    }
+    "close again after service initialization" in {
+      breaker ! ServiceFailed(1)
+      intercept[UnavailableException] {
+        breaker.ask("a").await
+      }
+      breaker ! ServiceInitialized
+      breaker.ask("a").await should be("re-a")
+    }
+    "reply with a special failure message on Write requests if open" in {
+      val events = Seq(DurableEvent("a", "emitter"))
+      breaker ! ServiceFailed(1)
+      breaker ! Write(events, probe.ref, probe.ref, 1, 2)
+      probe.expectMsg(WriteFailure(events, Exception, 1, 2))
+      probe.sender() should be(probe.ref)
+    }
+  }
+}


### PR DESCRIPTION
- closes #173
- fixes #174

Further changes

- Undo write request timeouts from previous commits (as they caused chaos tests to fail)
- Detailed documentation about failure handling strategies