### PR TITLE
Fix save snapshot failures when using PersistOnEvent

### DIFF
--- a/src/it/scala/com/rbmhtechnology/eventuate/PersistOnEventIntegrationSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/PersistOnEventIntegrationSpec.scala
@@ -19,6 +19,7 @@ package com.rbmhtechnology.eventuate
 import akka.actor._
 import akka.testkit._
 
+import com.rbmhtechnology.eventuate.EventsourcedView.Handler
 import com.rbmhtechnology.eventuate.log.EventLogLifecycleCassandra
 import com.rbmhtechnology.eventuate.log.EventLogLifecycleLeveldb
 
@@ -34,7 +35,7 @@ object PersistOnEventIntegrationSpec {
     }
     override def onEvent = {
       case Pong(10) => probe ! "done"
-      case Pong(i)  => persistOnEvent(Ping(i + 1))(Handler.empty)
+      case Pong(i)  => persistOnEvent(Ping(i + 1))
     }
   }
 
@@ -43,7 +44,7 @@ object PersistOnEventIntegrationSpec {
       case _ =>
     }
     override def onEvent = {
-      case Ping(i) => persistOnEvent(Pong(i))(Handler.empty)
+      case Ping(i) => persistOnEvent(Pong(i))
     }
   }
 }

--- a/src/it/scala/com/rbmhtechnology/eventuate/serializer/DurableEventSerializerSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/serializer/DurableEventSerializerSpec.scala
@@ -56,7 +56,7 @@ object DurableEventSerializerSpec {
     processId = "p4",
     localLogId = "p3",
     localSequenceNr = 17L,
-    deliveryId = "xyz")
+    persistOnEventSequenceNr = Some(12L))
 }
 
 class DurableEventSerializerSpec extends WordSpec with Matchers with BeforeAndAfterAll {

--- a/src/it/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializerSpec.scala
+++ b/src/it/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializerSpec.scala
@@ -21,7 +21,8 @@ import akka.serialization.SerializationExtension
 import akka.testkit.TestProbe
 
 import com.rbmhtechnology.eventuate._
-import com.rbmhtechnology.eventuate.ConfirmedDelivery.DeliveryAttempt
+import com.rbmhtechnology.eventuate.ConfirmedDelivery._
+import com.rbmhtechnology.eventuate.PersistOnEvent._
 import com.rbmhtechnology.eventuate.log.EventLogClock
 import com.rbmhtechnology.eventuate.serializer.DurableEventSerializerSpec.{event, ExamplePayload}
 
@@ -38,12 +39,18 @@ object SnapshotSerializerSpec {
   def last(payload: Any) =
     event.copy(payload = payload)
 
-  def unconfirmed(payload: Any, destination: ActorPath) = Vector(
+  def deliveryAttempts(payload: Any, destination: ActorPath) = Vector(
     DeliveryAttempt("3", payload, destination),
     DeliveryAttempt("4", payload, destination))
 
+  def persistOnEventRequests(payload: Any) = Vector(
+    PersistOnEventRequest(7L, Vector(PersistOnEventInvocation(payload, Set("a"))), 17),
+    PersistOnEventRequest(8L, Vector(PersistOnEventInvocation(payload, Set("b"))), 17))
+
   def snapshot(payload: Any, destination: ActorPath) =
-    Snapshot(payload, "x", last(payload), vectorTime(17, 18), unconfirmed(payload, destination))
+    Snapshot(payload, "x", last(payload), vectorTime(17, 18),
+      deliveryAttempts(payload, destination),
+      persistOnEventRequests(payload))
 
   def vectorTime(t1: Long, t2: Long): VectorTime =
     VectorTime("p1" -> t1, "p2" -> t2)

--- a/src/main/protobuf/DurableEventFormats.proto
+++ b/src/main/protobuf/DurableEventFormats.proto
@@ -27,7 +27,7 @@ message DurableEventFormat {
   optional string processId = 7;
   optional string localLogId = 8;
   optional int64 localSequenceNr = 9;
-  optional string deliveryId = 10;
+  optional int64 persistOnEventSequenceNr = 10;
 }
 
 message PayloadFormat {

--- a/src/main/protobuf/SnapshotFormats.proto
+++ b/src/main/protobuf/SnapshotFormats.proto
@@ -25,12 +25,24 @@ message SnapshotFormat {
   optional DurableEventFormat lastEvent = 3;
   optional VectorTimeFormat currentTime = 4;
   repeated DeliveryAttemptFormat deliveryAttempts = 5;
+  repeated PersistOnEventRequestFormat persistOnEventRequests = 6;
 }
 
 message DeliveryAttemptFormat {
   optional string deliveryId = 1;
   optional PayloadFormat message = 2;
   optional string destination = 3;
+}
+
+message PersistOnEventRequestFormat {
+  optional int64 persistOnEventSequenceNr = 1;
+  repeated PersistOnEventInvocationFormat invocation = 2;
+  optional int32 instanceId = 3;
+}
+
+message PersistOnEventInvocationFormat {
+  optional PayloadFormat event = 1;
+  repeated string customDestinationAggregateIds = 2;
 }
 
 message ConcurrentVersionsTreeFormat {

--- a/src/main/scala/com/rbmhtechnology/eventuate/ConfirmedDelivery.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/ConfirmedDelivery.scala
@@ -27,13 +27,14 @@ object ConfirmedDelivery {
 /**
  * Supports the reliable delivery of messages to destinations by enabling applications
  * to redeliver messages until they are confirmed by their destinations. Both, message
- * delivery and confirmation must be executed within an [[EventsourcedActor]]'s event handler.
- * New messages are delivered by calling `deliver`. When the destination replies with a confirmation
- * message, the [[EventsourcedActor]] must generate an event for which the handler calls `confirm`.
- * Until confirmation, delivered messages are tracked as ''unconfirmed'' messages. Unconfirmed
- * messages can be redelivered by calling `redeliverUnconfirmed`. This is usually done within a
- * command handler by processing scheduler messages. Redelivery occurs automatically when the
- * [[EventsourcedActor]] successfully recovered after initial start or a re-start.
+ * delivery and confirmation processing must be done within an [[EventsourcedActor]]'s
+ * event handler. New messages are delivered by calling `deliver`. When the destination
+ * replies with a confirmation message, the [[EventsourcedActor]] must generate an event
+ * for which the handler calls `confirm`. Until confirmation, delivered messages are
+ * tracked as ''unconfirmed'' messages. Unconfirmed messages can be redelivered by calling
+ * `redeliverUnconfirmed`. This is usually done within a command handler by processing
+ * scheduler messages. Redelivery occurs automatically when the [[EventsourcedActor]]
+ * successfully recovered after initial start or a re-start.
  */
 trait ConfirmedDelivery extends EventsourcedActor {
   import ConfirmedDelivery._
@@ -75,7 +76,7 @@ trait ConfirmedDelivery extends EventsourcedActor {
    */
   override private[eventuate] def snapshotCaptured(snapshot: Snapshot): Snapshot = {
     _unconfirmed.values.foldLeft(super.snapshotCaptured(snapshot)) {
-      case (s, da) => s.add(da)
+      case (s, da) => s.addDeliveryAttempt(da)
     }
   }
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/DurableEvent.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/DurableEvent.scala
@@ -41,8 +41,9 @@ import scala.collection.immutable.Seq
  *                  set `sharedClockEntry` to `false` then this is the id of that actor or processor (which is the `emitterId`).
  * @param localLogId Id of the local event log.
  * @param localSequenceNr Sequence number in the local event log.
- * @param deliveryId Set if an [[EventsourcedActor]] with a [[PersistOnEvent]] mixin emitted this event with `persistOnEvent`
- *                   or `persistOnEventN`.
+ * @param persistOnEventSequenceNr Sequence number of the event that caused the emission of this event in an event handler.
+ *                                 Defined if an [[EventsourcedActor]] with a [[PersistOnEvent]] mixin emitted this event
+ *                                 with `persistOnEvent`.
  */
 case class DurableEvent(
   payload: Any,
@@ -54,7 +55,7 @@ case class DurableEvent(
   processId: String = DurableEvent.UndefinedLogId,
   localLogId: String = DurableEvent.UndefinedLogId,
   localSequenceNr: Long = DurableEvent.UndefinedSequenceNr,
-  deliveryId: String = DurableEvent.UndefinedDeliveryId) {
+  persistOnEventSequenceNr: Option[Long] = None) {
 
   import DurableEvent._
 
@@ -103,7 +104,6 @@ case class DurableEvent(
 
 object DurableEvent {
   val UndefinedLogId = ""
-  val UndefinedDeliveryId = ""
   val UndefinedSequenceNr = 0L
 
   def apply(emitterId: String): DurableEvent =

--- a/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedClock.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedClock.scala
@@ -69,7 +69,7 @@ trait EventsourcedClock extends EventsourcedView {
   /**
    * Internal API.
    */
-  private[eventuate] def durableEvent(payload: Any, customDestinationAggregateIds: Set[String], deliveryId: String = UndefinedDeliveryId): DurableEvent = {
+  private[eventuate] def durableEvent(payload: Any, customDestinationAggregateIds: Set[String], persistOnEventSequenceNr: Option[Long] = None): DurableEvent = {
     if (sharedClockEntry) {
       DurableEvent(
         payload = payload,
@@ -78,7 +78,7 @@ trait EventsourcedClock extends EventsourcedView {
         customDestinationAggregateIds = customDestinationAggregateIds,
         vectorTimestamp = currentVectorTime,
         processId = UndefinedLogId,
-        deliveryId = deliveryId)
+        persistOnEventSequenceNr = persistOnEventSequenceNr)
     } else {
       DurableEvent(
         payload = payload,
@@ -87,7 +87,7 @@ trait EventsourcedClock extends EventsourcedView {
         customDestinationAggregateIds = customDestinationAggregateIds,
         vectorTimestamp = updateLocalTime(),
         processId = id,
-        deliveryId = deliveryId)
+        persistOnEventSequenceNr = persistOnEventSequenceNr)
     }
   }
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedView.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedView.scala
@@ -51,6 +51,10 @@ object EventsourcedView {
    */
   type Handler[A] = Try[A] => Unit
 
+  object Handler {
+    def empty[A]: Handler[A] = (_: Try[A]) => Unit
+  }
+
   /**
    * Internal API.
    */
@@ -90,10 +94,6 @@ trait EventsourcedView extends Actor with Stash with ActorLogging {
   import context.dispatcher
 
   type Handler[A] = EventsourcedView.Handler[A]
-
-  object Handler {
-    def empty[A]: Handler[A] = (_: Try[A]) => Unit
-  }
 
   val instanceId: Int = instanceIdCounter.getAndIncrement()
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/Snapshot.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/Snapshot.scala
@@ -17,6 +17,7 @@
 package com.rbmhtechnology.eventuate
 
 import com.rbmhtechnology.eventuate.ConfirmedDelivery.DeliveryAttempt
+import com.rbmhtechnology.eventuate.PersistOnEvent.PersistOnEventRequest
 
 /**
  * Snapshot metadata.
@@ -38,19 +39,25 @@ case class SnapshotMetadata(emitterId: String, sequenceNr: Long)
  * @param emitterId Id of the event-sourced actor, view, stateful writer or processor that saved the snapshot.
  * @param lastEvent Last handled event before the snapshot was saved.
  * @param currentTime Current vector time when the snapshot was saved.
- * @param deliveryAttempts Unconfirmed delivery attempts when the snapshot was saved (can only be
- *                         non-empty if the actor implements [[ConfirmedDelivery]]).
+ * @param deliveryAttempts Unconfirmed [[ConfirmedDelivery.DeliveryAttempt DeliveryAttempt]]s when the snapshot was
+ *                         saved (can only be non-empty if the actor implements [[ConfirmedDelivery]]).
+ * @param persistOnEventRequests Unconfirmed [[PersistOnEvent.PersistOnEventRequest PersistOnEventRequest]]s when the
+ *                               snapshot was saved (can only be non-empty if the actor implements [[PersistOnEvent]]).
  */
 case class Snapshot(
   payload: Any,
   emitterId: String,
   lastEvent: DurableEvent,
   currentTime: VectorTime,
-  deliveryAttempts: Vector[DeliveryAttempt] = Vector.empty) {
+  deliveryAttempts: Vector[DeliveryAttempt] = Vector.empty,
+  persistOnEventRequests: Vector[PersistOnEventRequest] = Vector.empty) {
 
   val metadata: SnapshotMetadata =
     SnapshotMetadata(emitterId, lastEvent.localSequenceNr)
 
-  def add(deliveryAttempt: DeliveryAttempt): Snapshot =
+  def addDeliveryAttempt(deliveryAttempt: DeliveryAttempt): Snapshot =
     copy(deliveryAttempts = deliveryAttempts :+ deliveryAttempt)
+
+  def addPersistOnEventRequest(persistOnEventRequest: PersistOnEventRequest): Snapshot =
+    copy(persistOnEventRequests = persistOnEventRequests :+ persistOnEventRequest)
 }

--- a/src/main/scala/com/rbmhtechnology/eventuate/serializer/CRDTSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/serializer/CRDTSerializer.scala
@@ -111,7 +111,7 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
   private def mvRegister(mvRegisterFormat: MVRegisterFormat): MVRegister[Any] = {
     val builder = new VectorBuilder[Registered[Any]]
 
-    val rs = mvRegisterFormat.getRegisteredList.asScala.iterator.foldLeft(Set.empty[Registered[Any]]) {
+    val rs = mvRegisterFormat.getRegisteredList.iterator.asScala.foldLeft(Set.empty[Registered[Any]]) {
       case (acc, r) => acc + registered(r)
     }
 
@@ -121,7 +121,7 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
   private def orSet(orSetFormat: ORSetFormat): ORSet[Any] = {
     val builder = new VectorBuilder[Versioned[Any]]
 
-    val ves = orSetFormat.getVersionedEntriesList.asScala.iterator.foldLeft(Set.empty[Versioned[Any]]) {
+    val ves = orSetFormat.getVersionedEntriesList.iterator.asScala.foldLeft(Set.empty[Versioned[Any]]) {
       case (acc, ve) => acc + snapshotSerializer.versioned(ve)
     }
 

--- a/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializer.scala
@@ -152,7 +152,7 @@ class ReplicationProtocolSerializer(system: ExtendedActorSystem) extends Seriali
   private def replicationReadSuccess(messageFormat: ReplicationReadSuccessFormat): ReplicationReadSuccess = {
     val builder = new VectorBuilder[DurableEvent]
 
-    messageFormat.getEventsList.iterator().asScala.foreach { eventFormat =>
+    messageFormat.getEventsList.iterator.asScala.foreach { eventFormat =>
       builder += eventSerializer.durableEvent(eventFormat)
     }
 

--- a/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicPersistOnEventSpec.scala
+++ b/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicPersistOnEventSpec.scala
@@ -21,6 +21,8 @@ import akka.remote.testkit._
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit.TestProbe
 
+import com.rbmhtechnology.eventuate.EventsourcedView.Handler
+
 class BasicPersistOnEventSpecLeveldb extends BasicPersistOnEventSpec with MultiNodeSupportLeveldb
 class BasicPersistOnEventSpecLeveldbMultiJvmNode1 extends BasicPersistOnEventSpecLeveldb
 class BasicPersistOnEventSpecLeveldbMultiJvmNode2 extends BasicPersistOnEventSpecLeveldb
@@ -50,7 +52,7 @@ object BasicPersistOnEventConfig extends MultiNodeConfig {
       case p @ Pong(10) => probe ! p
       case p @ Pong(5) => probe ! p
       case p @ Ping(6) => probe ! p
-      case Pong(i)  => persistOnEvent(Ping(i + 1))(Handler.empty)
+      case Pong(i)  => persistOnEvent(Ping(i + 1))
     }
   }
 
@@ -59,7 +61,7 @@ object BasicPersistOnEventConfig extends MultiNodeConfig {
       case _ =>
     }
     override def onEvent = {
-      case Ping(i) => persistOnEvent(Pong(i))(Handler.empty)
+      case Ping(i) => persistOnEvent(Pong(i))
     }
   }
 }

--- a/src/sphinx/code/UserGuideDoc.scala
+++ b/src/sphinx/code/UserGuideDoc.scala
@@ -382,6 +382,7 @@ object EventCollaboration {
 
   //#event-collaboration
   // some imports omitted ...
+  import com.rbmhtechnology.eventuate.EventsourcedView.Handler
   import com.rbmhtechnology.eventuate.EventsourcedActor
   import com.rbmhtechnology.eventuate.PersistOnEvent
 
@@ -397,7 +398,7 @@ object EventCollaboration {
 
     override def onEvent = {
       case Pong(10) if !recovering => completion ! "done"
-      case Pong(i)  => persistOnEvent(Ping(i + 1))(Handler.empty)
+      case Pong(i)  => persistOnEvent(Ping(i + 1))
     }
   }
 
@@ -408,7 +409,7 @@ object EventCollaboration {
       case _ =>
     }
     override def onEvent = {
-      case Ping(i) => persistOnEvent(Pong(i))(Handler.empty)
+      case Ping(i) => persistOnEvent(Pong(i))
     }
   }
 

--- a/src/sphinx/reference/event-sourcing.rst
+++ b/src/sphinx/reference/event-sourcing.rst
@@ -342,7 +342,7 @@ For an ``EventsourcedActor`` with ``stateSync`` set to ``true``, this means that
 ``persistOnEvent`` failure handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``EventsourcedActor``\ s can also persist events in the :ref:`event-handler` if they additionally extend PersistOnEvent_. An asynchronous ``persistOnEvent`` operation may also fail for reasons explained in :ref:`persist-failure-handling`. If a ``persistOnEvent`` operation fails, it may only be retried by restarting the actor. Applications should not call ``redeliverUnconfirmed`` as it may generate duplicates.
+``EventsourcedActor``\ s can also persist events in the :ref:`event-handler` if they additionally extend PersistOnEvent_. An asynchronous ``persistOnEvent`` operation may also fail for reasons explained in :ref:`persist-failure-handling`. If a ``persistOnEvent`` operation fails, the actor is automatically restarted by throwing a ``PersistOnEventException``.
 
 Recovery failure handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/sphinx/user-guide.rst
+++ b/src/sphinx/user-guide.rst
@@ -274,7 +274,7 @@ In more general cases, event-sourced actors of different type exchange events to
 .. includecode:: code/UserGuideDoc.scala
    :snippet: event-collaboration
 
-The ping-pong game is started by sending the ``PingActor`` a ``”serve”`` command which ``persist``\ s the first ``Ping`` event. This event however is not consumed by the emitter but rather by the ``PongActor``. The ``PongActor`` reacts on the ``Ping`` event by emitting a ``Pong`` event. Other than in previous examples, the event is not emitted in the actor’s ``onCommand`` handler but rather in the ``onEvent`` handler. For that purpose, the actor has to mixin the ``PersistOnEvent`` trait and use the ``persistOnEvent`` method. The emitted ``Pong`` too isn’t consumed by its emitter but rather by the ``PingActor``, emitting another ``Ping``, and so on. The game ends when the ``PingActor`` received the 10th ``Pong``.
+The ping-pong game is started by sending the ``PingActor`` a ``”serve”`` command which ``persist``\ s the first ``Ping`` event. This event however is not consumed by the emitter but rather by the ``PongActor``. The ``PongActor`` reacts on the ``Ping`` event by emitting a ``Pong`` event. Other than in previous examples, the event is not emitted in the actor’s ``onCommand`` handler but in the ``onEvent`` handler. For that purpose, the actor has to mixin the ``PersistOnEvent`` trait and use the ``persistOnEvent`` method. The emitted ``Pong`` too isn’t consumed by its emitter but rather by the ``PingActor``, emitting another ``Ping``, and so on. The game ends when the ``PingActor`` received the 10th ``Pong``.
 
 .. note::
    The ping-pong game is **reliable**. When an actor crashes and is re-started, the game is reliably resumed from where it was interrupted. The ``persistOnEvent`` method is idempotent i.e. no duplicates are written under failure conditions and later event replay. When deployed at different location, the ping-pong actors are also **partition-tolerant**. When their game is interrupted by a network partition, it is automatically resumed when the partition heals. 
@@ -284,7 +284,7 @@ The ping-pong game is started by sending the ``PingActor`` a ``”serve”`` com
 In a more real-world example, there would be several actors of different type collaborating to achieve a common goal, for example, in a distributed business process. These actors can be considered as event-driven and event-sourced *microservices*, collaborating on a causally ordered event stream in a reliable and partition-tolerant way. Furthermore, when partitioned, they remain available for local writes and automatically catch up with their collaborators when the partition heals.
 
 .. hint::
-   Further ``persistOnEvent`` failure handling options for are covered in the PersistOnEvent_ API docs.
+   Further ``persistOnEvent`` details are described in the PersistOnEvent_ API docs.
 
 .. _ZooKeeper: http://zookeeper.apache.org/
 .. _event sourcing: http://martinfowler.com/eaaDev/EventSourcing.html


### PR DESCRIPTION
- fixes #194
- No user-defined persistOnEvent handlers
- Persisted events must be handler in event handler
- Persistence failures throw PersistOnEventException

- Re-implementation of PersistOnEvent
- Composition with ConfirmedDelivery possible
- redeliverUnconfirmed allowed in context of PersistOnEvent