### PR TITLE
Support custom serializers with string-manifest

### DIFF
--- a/src/main/protobuf/DurableEventFormats.proto
+++ b/src/main/protobuf/DurableEventFormats.proto
@@ -17,6 +17,8 @@
 option java_package = "com.rbmhtechnology.eventuate.serializer";
 option optimize_for = SPEED;
 
+import "PayloadFormats.proto";
+
 message DurableEventFormat {
   optional PayloadFormat payload = 1;
   optional string emitterId = 2;
@@ -28,12 +30,6 @@ message DurableEventFormat {
   optional string localLogId = 8;
   optional int64 localSequenceNr = 9;
   optional int64 persistOnEventSequenceNr = 10;
-}
-
-message PayloadFormat {
-  optional int32 serializerId = 1;
-  optional bytes payload = 2;
-  optional bytes payloadManifest = 3;
 }
 
 message VectorTimeEntryFormat {

--- a/src/main/protobuf/PayloadFormats.proto
+++ b/src/main/protobuf/PayloadFormats.proto
@@ -17,26 +17,13 @@
 option java_package = "com.rbmhtechnology.eventuate.serializer";
 option optimize_for = SPEED;
 
-import "DurableEventFormats.proto";
-import "SnapshotFormats.proto";
-import "PayloadFormats.proto";
-
-message ORSetFormat {
-  repeated VersionedFormat versionedEntries = 1;
+/*
+ * This message is used for (de-)serializing custom payloads, like
+ * custom events, snapshots or replication filters
+ */
+message PayloadFormat {
+  optional int32 serializerId = 1;
+  optional bytes payload = 2;
+  optional string payloadManifest = 3;
+  optional bool isStringManifest = 4;
 }
-
-message LWWRegisterFormat {
-  optional MVRegisterFormat mvRegister = 1;
-}
-
-message MVRegisterFormat {
-  repeated RegisteredFormat registered = 1;
-}
-
-message RegisteredFormat {
-  optional VectorTimeFormat updateTimestamp = 1;
-  optional int64 systemTimestamp = 2;
-  optional string emitterId = 3;
-  optional PayloadFormat payload = 4;
-}
-

--- a/src/main/protobuf/ReplicationFilterFormats.proto
+++ b/src/main/protobuf/ReplicationFilterFormats.proto
@@ -17,11 +17,7 @@
 option java_package = "com.rbmhtechnology.eventuate.serializer";
 option optimize_for = SPEED;
 
-message ReplicationFilterLeafFormat {
-  optional int32 serializerId = 1;
-  optional bytes filter = 2;
-  optional bytes filterManifest = 3;
-}
+import "PayloadFormats.proto";
 
 message ReplicationFilterTreeFormat {
   enum NodeType {
@@ -31,7 +27,7 @@ message ReplicationFilterTreeFormat {
   }
   required NodeType nodeType = 1;
   repeated ReplicationFilterTreeFormat children = 2; // set if nodeType == AND | OR
-  optional ReplicationFilterLeafFormat filter = 3;   // set if nodeType == LEAF
+  optional PayloadFormat filter = 3;   // set if nodeType == LEAF
 }
 
 message NoFilterFormat {

--- a/src/main/protobuf/SnapshotFormats.proto
+++ b/src/main/protobuf/SnapshotFormats.proto
@@ -18,6 +18,7 @@ option java_package = "com.rbmhtechnology.eventuate.serializer";
 option optimize_for = SPEED;
 
 import "DurableEventFormats.proto";
+import "PayloadFormats.proto";
 
 message SnapshotFormat {
   optional PayloadFormat payload = 1;

--- a/src/main/scala/com/rbmhtechnology/eventuate/serializer/PayloadSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/serializer/PayloadSerializer.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.serializer
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.SerializationExtension
+import akka.serialization.SerializerWithStringManifest
+import com.google.protobuf.ByteString
+import com.rbmhtechnology.eventuate.serializer.PayloadFormats.PayloadFormat
+
+trait PayloadSerializer {
+
+  protected def system: ExtendedActorSystem
+
+  def payloadFormatBuilder(payload: AnyRef) = {
+    val serializer = SerializationExtension(system).findSerializerFor(payload)
+    val builder = PayloadFormat.newBuilder()
+
+    if (serializer.includeManifest) {
+      val stringManifest = serializer match {
+        case serializerWithStringManifest: SerializerWithStringManifest =>
+          builder.setIsStringManifest(true)
+          serializerWithStringManifest.manifest(payload)
+        case _ =>
+          payload.getClass.getName
+      }
+      builder.setPayloadManifest(stringManifest)
+    }
+
+    builder.setPayload(ByteString.copyFrom(serializer.toBinary(payload)))
+    builder.setSerializerId(serializer.identifier)
+    builder
+  }
+
+  def payload(payloadFormat: PayloadFormat): Any = {
+    val deserialized = if (payloadFormat.getIsStringManifest) {
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        payloadFormat.getSerializerId,
+        payloadFormat.getPayloadManifest)
+    } else if (payloadFormat.hasPayloadManifest) {
+      val manifestClass = system.dynamicAccess.getClassFor[AnyRef](payloadFormat.getPayloadManifest).get
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        manifestClass)
+    } else {
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        payloadFormat.getSerializerId,
+        None)
+    }
+    deserialized.get
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/snapshot/filesystem/FilesystemSnapshotStore.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/snapshot/filesystem/FilesystemSnapshotStore.scala
@@ -73,7 +73,7 @@ class FilesystemSnapshotStore(settings: FilesystemSnapshotStoreSettings, logId: 
       case Some(snr) => Try(withInputStream(dir, snr)(deserialize)) match {
         case Success(s) => Some(s)
         case Failure(e) =>
-          log.error(s"error loading snapshot ${dstFile(dir, snr)}")
+          log.error(e, s"error loading snapshot ${dstFile(dir, snr)}")
           go(snrs.tail)
       }
     }

--- a/src/sphinx/reference/event-sourcing.rst
+++ b/src/sphinx/reference/event-sourcing.rst
@@ -460,6 +460,15 @@ Custom serializers can also be configured for the type parameter ``A`` of ``MVRe
 
 Event-sourced actors that extend ``ConfirmedDelivery`` for :ref:`reliable-delivery` of messages to destinations will also include unconfirmed messages as ``deliveryAttempts`` in a Snapshot_. The ``message`` field of a DeliveryAttempt_ can also be custom-serialized by configuring a serializer.
 
+Resolution of serializers when deserializing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When eventuate serializes application-defined events, :ref:`replication-filters` or snapshots it includes the ``identifier`` of the Akka serializer and the class or string based manifest_ when available. When deserializing these application-defined payloads a serializer is selected as follows:
+
+- If a class-based manifest is included, the serializer that is configured in the Akka configuration for this class is selected
+- In case of a string-based manifest or no manifest the serializer is selected by the included ``identifier``
+
+
 .. [#] The ``customDestinationAggregateIds`` parameter is described in section :ref:`event-routing`.
 .. [#] Writes from different event-sourced actors that have ``stateSync`` set to ``true`` are still batched, but not the writes from a single event-sourced actor.
 .. [#] Event replay can optionally start from :ref:`snapshots` of actor state.
@@ -471,6 +480,7 @@ Event-sourced actors that extend ``ConfirmedDelivery`` for :ref:`reliable-delive
 .. _watch: http://doc.akka.io/docs/akka/2.4.1/scala/actors.html#deathwatch-scala
 .. _serialization extension: http://doc.akka.io/docs/akka/2.4.1/scala/serialization.html
 .. _Serializer: http://doc.akka.io/api/akka/2.4.1/#akka.serialization.Serializer
+.. _manifest: http://doc.akka.io/docs/akka/2.4.1/scala/serialization.html#Serializer_with_String_Manifest
 .. _Protocol Buffers: https://developers.google.com/protocol-buffers/
 .. _plausible clocks: https://github.com/RBMHTechnology/eventuate/issues/68
 .. _Cassandra: http://cassandra.apache.org/


### PR DESCRIPTION
When serializing a DurableEvent's or snapshots payload or
a custom ReplicationFilter include a string-manifest,
if the custom serializer is a SerializerWithStringManifest
and use corresponding deserialize-method.

closes #207