### PR TITLE
safer tracking of issued leveldb iterators

### DIFF
--- a/eventuate-log-leveldb/src/main/resources/reference.conf
+++ b/eventuate-log-leveldb/src/main/resources/reference.conf
@@ -18,5 +18,10 @@ eventuate {
     # Delay between two tries to physically delete all requested events while
     # keeping those that are not yet replicated.
     deletion-retry-delay = 1m
+
+    # The maximum duration to wait for outstanding iterators being closed during
+    # shutdown. If there are iterators still left after this period closing will
+    # be aborted with an exception and the LevelDB handle will not be closed.
+    iterator-close-wait-max = 30s
   }
 }


### PR DESCRIPTION
Previously, creating an iterator and tracking wasn't an atomic operation
resulting in iterator operations being run after the db had been closed.
This resulted in all kinds of crashes because of illegal native state
during the shutdown procedure.

/cc @volkerstampa 