### PR TITLE
Upper bound on source log scan progress

### DIFF
--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/LocationSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/LocationSpec.scala
@@ -60,8 +60,8 @@ object SingleLocationSpec {
     abstract override def read(fromSequenceNr: Long, toSequenceNr: Long, max: Int, aggregateId: String): Future[BatchReadResult] =
       if (fromSequenceNr == ErrorSequenceNr) Future.failed(IntegrationTestException) else super.read(fromSequenceNr, toSequenceNr, max, aggregateId)
 
-    abstract override def replicationRead(fromSequenceNr: Long, toSequenceNr: Long, max: Int, filter: (DurableEvent) => Boolean): Future[BatchReadResult] =
-      if (fromSequenceNr == ErrorSequenceNr) Future.failed(IntegrationTestException) else super.replicationRead(fromSequenceNr, toSequenceNr, max, filter)
+    abstract override def replicationRead(fromSequenceNr: Long, toSequenceNr: Long, max: Int, scanSize: Int, filter: (DurableEvent) => Boolean): Future[BatchReadResult] =
+      if (fromSequenceNr == ErrorSequenceNr) Future.failed(IntegrationTestException) else super.replicationRead(fromSequenceNr, toSequenceNr, max, scanSize, filter)
 
     abstract override def write(events: Seq[DurableEvent], partition: Long, clock: EventLogClock): Unit =
       if (events.map(_.payload).contains("boom")) throw IntegrationTestException else super.write(events, partition, clock)

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/ReplicationIntegrationSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/ReplicationIntegrationSpec.scala
@@ -279,7 +279,7 @@ trait ReplicationIntegrationSpec extends WordSpec with Matchers with MultiLocati
     val locationA = location("A")
     val endpointA = locationA.endpoint(Set("L1"), Set(), sourceApplicationName, sourceApplicationVersion)
 
-    val message = ReplicationRead(1, Int.MaxValue, NoFilter, DurableEvent.UndefinedLogId, locationA.system.deadLetters, VectorTime())
+    val message = ReplicationRead(1, Int.MaxValue, Int.MaxValue, NoFilter, DurableEvent.UndefinedLogId, locationA.system.deadLetters, VectorTime())
     val envelope = ReplicationReadEnvelope(message, "L1", targetApplicationName, targetApplicationVersion)
 
     endpointA.acceptor.tell(envelope, locationA.probe.ref)

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializerSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializerSpec.scala
@@ -36,16 +36,16 @@ object ReplicationProtocolSerializerSpec {
   val replicationReadSuccess =
     ReplicationReadSuccess(List(
       DurableEvent("a", "r1"),
-      DurableEvent("b", "r2")), 27L, "B", VectorTime("X" -> 4L))
+      DurableEvent("b", "r2")), 27L, "B", VectorTime("X" -> 4L), true)
 
   val replicationReadFailure =
     ReplicationReadFailure("test", "B")
 
   def replicationRead1(r: ActorRef) =
-    ReplicationRead(17L, 10, filter1(), "A", r, VectorTime("X" -> 12L))
+    ReplicationRead(17L, 10, 100, filter1(), "A", r, VectorTime("X" -> 12L))
 
   def replicationRead2(r: ActorRef) =
-    ReplicationRead(18L, 11, filter3, "B", r, VectorTime("Y" -> 13L))
+    ReplicationRead(18L, 11, 100, filter3, "B", r, VectorTime("Y" -> 13L))
 
   def replicationReadEnvelope(r: ReplicationRead): ReplicationReadEnvelope =
     ReplicationReadEnvelope(r, "X", "myapp", ApplicationVersion(2, 1))

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/utilities/package.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/utilities/package.scala
@@ -47,7 +47,7 @@ package object utilities {
     implicit val timeout = Timeout(3.seconds)
 
     def readEvents: Future[ReplicationReadSuccess] =
-      target.log.ask(ReplicationRead(1L, Int.MaxValue, NoFilter, DurableEvent.UndefinedLogId, target.endpoint.system.deadLetters, VectorTime())).mapTo[ReplicationReadSuccess]
+      target.log.ask(ReplicationRead(1L, Int.MaxValue, Int.MaxValue, NoFilter, DurableEvent.UndefinedLogId, target.endpoint.system.deadLetters, VectorTime())).mapTo[ReplicationReadSuccess]
 
     val reading = for {
       res <- readEvents
@@ -64,10 +64,10 @@ package object utilities {
       to.log.ask(GetReplicationProgress(from.logId)).mapTo[GetReplicationProgressSuccess]
 
     def readEvents(reply: GetReplicationProgressSuccess): Future[ReplicationReadSuccess] =
-      from.log.ask(ReplicationRead(reply.storedReplicationProgress + 1, num, NoFilter, to.logId, to.endpoint.system.deadLetters, reply.currentTargetVersionVector)).mapTo[ReplicationReadSuccess]
+      from.log.ask(ReplicationRead(reply.storedReplicationProgress + 1, num, Int.MaxValue, NoFilter, to.logId, to.endpoint.system.deadLetters, reply.currentTargetVersionVector)).mapTo[ReplicationReadSuccess]
 
     def writeEvents(reply: ReplicationReadSuccess): Future[ReplicationWriteSuccess] =
-      to.log.ask(ReplicationWrite(reply.events, from.logId, reply.replicationProgress, VectorTime())).mapTo[ReplicationWriteSuccess]
+      to.log.ask(ReplicationWrite(reply.events, from.logId, reply.replicationProgress, VectorTime(), hasMore = false)).mapTo[ReplicationWriteSuccess]
 
     val replication = for {
       rps <- readProgress

--- a/eventuate-core/src/main/protobuf/ReplicationProtocolFormats.proto
+++ b/eventuate-core/src/main/protobuf/ReplicationProtocolFormats.proto
@@ -58,10 +58,11 @@ message ReplicationReadEnvelopeIncompatibleFormat {
 message ReplicationReadFormat {
   optional int64 fromSequenceNr = 1;
   optional int32 max = 2;
-  optional ReplicationFilterTreeFormat filter = 3;
-  optional string targetLogId = 4;
-  optional string replicator = 5;
-  optional VectorTimeFormat currentTargetVersionVector = 6;
+  optional int32 scanSize = 3;
+  optional ReplicationFilterTreeFormat filter = 4;
+  optional string targetLogId = 5;
+  optional string replicator = 6;
+  optional VectorTimeFormat currentTargetVersionVector = 7;
 }
 
 message ReplicationReadSuccessFormat {
@@ -69,6 +70,7 @@ message ReplicationReadSuccessFormat {
   optional int64 replicationProgress = 2;
   optional string targetLogId = 3;
   optional VectorTimeFormat currentSourceVersionVector = 4;
+  optional bool hasMore = 5;
 }
 
 message ReplicationReadFailureFormat {

--- a/eventuate-core/src/main/resources/reference.conf
+++ b/eventuate-core/src/main/resources/reference.conf
@@ -59,6 +59,10 @@ eventuate {
     # Timeout for reading events from the remote source log.
     remote-read-timeout = 10s
 
+    # Maximum number of events to scan in a remote event log per replication
+    # read request.
+    remote-scan-size = 65536
+
     # Maximum duration of missing heartbeats from a remote replication
     # endpoint until that endpoint is considered unavailable.
     failure-detection-limit = 60s

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
@@ -120,9 +120,9 @@ trait EventsourcedProcessor extends EventsourcedWriter[Long, Long] {
    */
   override final def write(): Future[Long] =
     if (lastSequenceNr > processingProgress) {
-      val result = targetEventLog.ask(ReplicationWrite(processedEvents, id, lastSequenceNr, VectorTime.Zero))(Timeout(writeTimeout)).flatMap {
-        case ReplicationWriteSuccess(_, _, progress, _) => Future.successful(progress)
-        case ReplicationWriteFailure(cause)             => Future.failed(cause)
+      val result = targetEventLog.ask(ReplicationWrite(processedEvents, id, lastSequenceNr, VectorTime.Zero, hasMore = false))(Timeout(writeTimeout)).flatMap {
+        case ReplicationWriteSuccess(_, _, progress, _, _) => Future.successful(progress)
+        case ReplicationWriteFailure(cause)                => Future.failed(cause)
       }
       processedEvents = Vector.empty
       result

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/Recovery.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/Recovery.scala
@@ -280,9 +280,9 @@ private class RecoveryActor(endpointId: String, link: RecoveryLink) extends Acto
   def recoveringMetadata: Receive = {
     case r: ReplicationRead if r.fromSequenceNr > link.localClock.sequenceNr + 1L =>
       println(s"[recovery of ${endpointId}] Trigger update of inconsistent replication progress at ${link.remoteLogId} ...")
-      sender() ! ReplicationReadSuccess(Seq(), link.localClock.sequenceNr, link.remoteLogId, link.localClock.versionVector)
+      sender() ! ReplicationReadSuccess(Seq(), link.localClock.sequenceNr, link.remoteLogId, link.localClock.versionVector, hasMore = true)
     case r: ReplicationRead =>
-      sender() ! ReplicationReadSuccess(Seq(), r.fromSequenceNr - 1L, link.remoteLogId, link.localClock.versionVector)
+      sender() ! ReplicationReadSuccess(Seq(), r.fromSequenceNr - 1L, link.remoteLogId, link.localClock.versionVector, hasMore = false)
       context.parent ! RecoveryStepCompleted(link)
       context.become(recoveringEvents)
   }

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/ReplicationProtocol.scala
@@ -162,7 +162,7 @@ object ReplicationProtocol {
    * Instructs a source log to read up to `max` events starting at `fromSequenceNr` and applying
    * the given replication `filter`.
    */
-  case class ReplicationRead(fromSequenceNr: Long, max: Int, filter: ReplicationFilter, targetLogId: String, replicator: ActorRef, currentTargetVersionVector: VectorTime) extends Format
+  case class ReplicationRead(fromSequenceNr: Long, max: Int, scanSize: Int, filter: ReplicationFilter, targetLogId: String, replicator: ActorRef, currentTargetVersionVector: VectorTime) extends Format
 
   /**
    * Success reply after a [[ReplicationRead]].
@@ -172,7 +172,7 @@ object ReplicationProtocol {
    *                            or equal to the sequence number of the last read
    *                            event (if any).
    */
-  case class ReplicationReadSuccess(events: Seq[DurableEvent], replicationProgress: Long, targetLogId: String, currentSourceVersionVector: VectorTime) extends DurableEventBatch with Format
+  case class ReplicationReadSuccess(events: Seq[DurableEvent], replicationProgress: Long, targetLogId: String, currentSourceVersionVector: VectorTime, hasMore: Boolean) extends DurableEventBatch with Format
 
   /**
    * Failure reply after a [[ReplicationRead]].
@@ -193,7 +193,7 @@ object ReplicationProtocol {
    * Instructs a target log to write replicated `events` from the source log identified by
    * `sourceLogId` along with the last read position in the source log (`replicationProgress`).
    */
-  case class ReplicationWrite(events: Seq[DurableEvent], sourceLogId: String, replicationProgress: Long, currentSourceVersionVector: VectorTime, replyTo: ActorRef = null) extends UpdateableEventBatch[ReplicationWrite] {
+  case class ReplicationWrite(events: Seq[DurableEvent], sourceLogId: String, replicationProgress: Long, currentSourceVersionVector: VectorTime, hasMore: Boolean, replyTo: ActorRef = null) extends UpdateableEventBatch[ReplicationWrite] {
     override def update(events: Seq[DurableEvent]): ReplicationWrite = copy(events = events)
   }
 
@@ -205,7 +205,7 @@ object ReplicationProtocol {
    * @param storedReplicationProgress Last source log read position stored in the target log.
    * @param currentTargetVersionVector [[log.EventLogClock.versionVector Version vector]] of the target log after the events were written
    */
-  case class ReplicationWriteSuccess(num: Int, sourceLogId: String, storedReplicationProgress: Long, currentTargetVersionVector: VectorTime)
+  case class ReplicationWriteSuccess(num: Int, sourceLogId: String, storedReplicationProgress: Long, currentTargetVersionVector: VectorTime, hasMore: Boolean)
 
   /**
    * Failure reply after a [[ReplicationWrite]].

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationProtocolSerializer.scala
@@ -109,6 +109,7 @@ class ReplicationProtocolSerializer(system: ExtendedActorSystem) extends Seriali
     builder.setReplicationProgress(message.replicationProgress)
     builder.setTargetLogId(message.targetLogId)
     builder.setCurrentSourceVersionVector(commonSerializer.vectorTimeFormatBuilder(message.currentSourceVersionVector))
+    builder.setHasMore(message.hasMore)
     builder
   }
 
@@ -116,6 +117,7 @@ class ReplicationProtocolSerializer(system: ExtendedActorSystem) extends Seriali
     val builder = ReplicationReadFormat.newBuilder()
     builder.setFromSequenceNr(message.fromSequenceNr)
     builder.setMax(message.max)
+    builder.setScanSize(message.scanSize)
     builder.setFilter(filterSerializer.filterTreeFormatBuilder(message.filter))
     builder.setTargetLogId(message.targetLogId)
     builder.setReplicator(Serialization.serializedActorPath(message.replicator))
@@ -182,13 +184,15 @@ class ReplicationProtocolSerializer(system: ExtendedActorSystem) extends Seriali
       builder.result(),
       messageFormat.getReplicationProgress,
       messageFormat.getTargetLogId,
-      commonSerializer.vectorTime(messageFormat.getCurrentSourceVersionVector))
+      commonSerializer.vectorTime(messageFormat.getCurrentSourceVersionVector),
+      messageFormat.getHasMore)
   }
 
   private def replicationRead(messageFormat: ReplicationReadFormat): ReplicationRead =
     ReplicationRead(
       messageFormat.getFromSequenceNr,
       messageFormat.getMax,
+      messageFormat.getScanSize,
       filterSerializer.filterTree(messageFormat.getFilter),
       messageFormat.getTargetLogId,
       system.provider.resolveActorRef(messageFormat.getReplicator),

--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedProcessorSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedProcessorSpec.java
@@ -124,12 +124,12 @@ public class AbstractEventsourcedProcessorSpec extends BaseSpec {
     }
 
     private void processWriteSuccess(final long progress, final DurableEvent... events) {
-        targetProbe.expectMsg(new ReplicationWrite(toSeq(events), EMITTER_ID, progress, vectorTimeZero(), null));
-        processResult(new ReplicationWriteSuccess(events.length, EMITTER_ID, progress, vectorTimeZero()));
+        targetProbe.expectMsg(new ReplicationWrite(toSeq(events), EMITTER_ID, progress, vectorTimeZero(), false, null));
+        processResult(new ReplicationWriteSuccess(events.length, EMITTER_ID, progress, vectorTimeZero(), false));
     }
 
     private void processWriteFailure(final long progress, final DurableEvent... events) {
-        targetProbe.expectMsg(new ReplicationWrite(toSeq(events), EMITTER_ID, progress, vectorTimeZero(), null));
+        targetProbe.expectMsg(new ReplicationWrite(toSeq(events), EMITTER_ID, progress, vectorTimeZero(), false, null));
         processResult(new ReplicationWriteFailure(FAILURE));
     }
 

--- a/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedProcessorSpec.scala
+++ b/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedProcessorSpec.scala
@@ -132,9 +132,9 @@ class EventsourcedProcessorSpec extends TestKit(ActorSystem("test")) with WordSp
   }
 
   def processWrite(progress: Long, events: Seq[DurableEvent], success: Boolean = true): Unit = {
-    trgProbe.expectMsg(ReplicationWrite(events, emitterIdB, progress, VectorTime()))
+    trgProbe.expectMsg(ReplicationWrite(events, emitterIdB, progress, VectorTime(), hasMore = false))
     if (success) {
-      processResult(ReplicationWriteSuccess(events.size, emitterIdB, progress, VectorTime()))
+      processResult(ReplicationWriteSuccess(events.size, emitterIdB, progress, VectorTime(), hasMore = false))
       appProbe.expectMsg(progress)
     } else {
       processResult(ReplicationWriteFailure(TestException))

--- a/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/log/NotificationChannelSpec.scala
+++ b/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/log/NotificationChannelSpec.scala
@@ -68,16 +68,16 @@ class NotificationChannelSpec extends TestKit(ActorSystem("test")) with WordSpec
   }
 
   def sourceReadMessage(targetLogId: String, targetVersionVector: VectorTime, filter: ReplicationFilter = NoFilter, probe: TestProbe = probe): ReplicationRead =
-    ReplicationRead(1L, 10, filter, targetLogId, probe.ref, targetVersionVector)
+    ReplicationRead(1L, 10, 100, filter, targetLogId, probe.ref, targetVersionVector)
 
   def sourceReadSuccessMessage(targetLogId: String): ReplicationReadSuccess =
-    ReplicationReadSuccess(Nil, 10L, targetLogId, VectorTime.Zero)
+    ReplicationReadSuccess(Nil, 10L, targetLogId, VectorTime.Zero, hasMore = true)
 
   def sourceUpdate(events: Seq[DurableEvent]): Unit =
     channel ! Updated(events)
 
   def replicaVersionUpdate(targetLogId: String, targetVersionVector: VectorTime): Unit =
-    channel ! ReplicationWrite(Nil, targetLogId, 10L, targetVersionVector)
+    channel ! ReplicationWrite(Nil, targetLogId, 10L, targetVersionVector, hasMore = true)
 
   "A notification channel" must {
     "send a notification if an update is not the causal past of the target" in {

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -248,7 +248,7 @@ class CircuitBreakerIntregrationSpecCassandra extends TestKit(ActorSystem("test"
   }
 
   def assertUnavailable(): Unit = {
-    val w = ReplicationWrite(Seq(), "source", 0L, VectorTime.Zero)
+    val w = ReplicationWrite(Seq(), "source", 0L, VectorTime.Zero, hasMore = false)
     eventually {
       intercept[UnavailableException] { log.ask(w).await }
     }
@@ -256,7 +256,7 @@ class CircuitBreakerIntregrationSpecCassandra extends TestKit(ActorSystem("test"
 
   def write(payload: Any, sequenceNr: Long)(implicit executor: ExecutionContext): Future[Int] = {
     val e = DurableEvent(payload, "emitter", vectorTimestamp = VectorTime("source" -> sequenceNr))
-    val w = ReplicationWrite(Seq(e), "source", sequenceNr, VectorTime.Zero)
+    val w = ReplicationWrite(Seq(e), "source", sequenceNr, VectorTime.Zero, hasMore = false)
 
     log.ask(w) flatMap {
       case s: ReplicationWriteSuccess => Future.successful(s.num)

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
@@ -71,7 +71,7 @@ class EventLogSpecCassandra extends TestKit(ActorSystem("test", EventLogSpecCass
       writeEmittedEvents(events)
 
       1 to num foreach { i =>
-        log.tell(ReplicationRead(i, 1, NoFilter, "test-target-log-id", dl, VectorTime()), probe.ref)
+        log.tell(ReplicationRead(i, 1, 100, NoFilter, "test-target-log-id", dl, VectorTime()), probe.ref)
         probe.expectMsgClass(classOf[ReplicationReadSuccess])
       }
     }
@@ -205,8 +205,8 @@ class EventLogSpecCassandra extends TestKit(ActorSystem("test", EventLogSpecCass
       generateEmittedEvents()
       generateReplicatedEvents()
       (log ? Delete(generatedReplicatedEvents(1).localSequenceNr)).await
-      log.tell(ReplicationRead(1, Int.MaxValue, NoFilter, UndefinedLogId, dl, VectorTime()), replyToProbe.ref)
-      replyToProbe.expectMsg(ReplicationReadSuccess(generatedEmittedEvents ++ generatedReplicatedEvents, 6, UndefinedLogId, VectorTime(logId -> 3L, remoteLogId -> 9L)))
+      log.tell(ReplicationRead(1, Int.MaxValue, Int.MaxValue, NoFilter, UndefinedLogId, dl, VectorTime()), replyToProbe.ref)
+      replyToProbe.expectMsg(ReplicationReadSuccess(generatedEmittedEvents ++ generatedReplicatedEvents, 6, UndefinedLogId, VectorTime(logId -> 3L, remoteLogId -> 9L), hasMore = false))
     }
   }
 }


### PR DESCRIPTION
- can be configured with eventuate.log.replication.remote-scan-size
- closes #236