### PR TITLE
Stateful processor calls processEvent for previously processed events

### DIFF
--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedProcessor.scala
@@ -110,8 +110,9 @@ trait EventsourcedProcessor extends EventsourcedWriter[Long, Long] {
    */
   override final def onEvent = {
     case payload if processEvent.isDefinedAt(payload) =>
+      val currentProcessedEvents = processEvent(payload)
       if (lastSequenceNr > processingProgress)
-        processedEvents = processEvent(payload).map(createEvent(_, lastHandledEvent.customDestinationAggregateIds)).foldLeft(processedEvents)(_ :+ _)
+        processedEvents = currentProcessedEvents.map(createEvent(_, lastHandledEvent.customDestinationAggregateIds)).foldLeft(processedEvents)(_ :+ _)
   }
 
   /**


### PR DESCRIPTION
This works with little to no overheard because regular (ie. non-stateful) processors won't be called for previously processed events. Stateful processors return None in `readSuccess`, so `onEvent` will be called for old events (snapshots aside). That said, the interaction between the var `processingProgress` and the return value of `readSuccess` is a bit tricky.