### PR TITLE
Updated the Cassandra driver to 3.0.1 and Cassandra Unit to 3.0.0.1

### DIFF
--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
@@ -147,7 +147,11 @@ class CassandraEventLog(id: String) extends EventLog[CassandraEventLogState](id)
         context.parent ! ServiceFailed(num)
         logger.error(e, s"write attempt ${num} failed: timeout after ${cassandra.settings.writeTimeout} ms - retry now")
         writeRetry(events, partition, clock, num + 1)
-      case Failure(e: QueryTimeoutException) =>
+      case Failure(e: WriteTimeoutException) =>
+        context.parent ! ServiceFailed(num)
+        logger.error(e, s"write attempt ${num} failed - retry now")
+        writeRetry(events, partition, clock, num + 1)
+      case Failure(e: OperationTimedOutException) =>
         context.parent ! ServiceFailed(num)
         logger.error(e, s"write attempt ${num} failed - retry now")
         writeRetry(events, partition, clock, num + 1)

--- a/project/ProjectDependencies.scala
+++ b/project/ProjectDependencies.scala
@@ -27,8 +27,8 @@ object ProjectDependencies {
   val AkkaRemote = "com.typesafe.akka" %% "akka-remote" % AkkaVersion
   val AkkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
   val AkkaTestkitMultiNode = "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion
-  val CassandraDriver = "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.9"
-  val CassandraUnit = "org.cassandraunit" % "cassandra-unit" % "2.0.2.2"
+  val CassandraDriver = "com.datastax.cassandra" % "cassandra-driver-core" % "3.0.1"
+  val CassandraUnit = "org.cassandraunit" % "cassandra-unit" % "3.0.0.1"
   val CommonsIo =  "commons-io" % "commons-io" % "2.4"
   val Leveldb = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8"
   val Java8Compat = "org.scala-lang.modules" % "scala-java8-compat_2.11" % "0.7.0"


### PR DESCRIPTION
Modified project dependencies to point to the Java Cassandra driver version 3.0.1. Updated the dependencies
well to point to Cassandra Unit 3.0.0.1. Updated the CassandraEventLog class to conform to the new driver
by removing the QueryTimeoutException and replacing it with OperationTimeoutException and
WriteTimeoutException since the QueryTimeoutException class is removed in the 3.0 Java driver.

This will allow for users of Eventuate to leverage Cassandra 3.x since it requires the Java 3.0+ driver.