### PR TITLE
Make CircuitBreaker publish (Un)Available

### DIFF
--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
@@ -605,6 +605,19 @@ abstract class EventLog[A <: EventLogState](id: String) extends Actor with Event
 }
 
 object EventLog {
+
+  /**
+   * Published on the event-stream, when the [[CircuitBreaker]] closes as a write finally
+   * was successful (after n retries).
+   */
+  case class EventLogAvailable(logId: String)
+
+  /**
+   * Published on the event-stream, if the [[CircuitBreaker]] opens due to an error
+   * when writing events after a configured number of retries.
+   */
+  case class EventLogUnavailable(logId: String, initialCause: Throwable)
+
   /**
    * Periodically sent to an [[EventLog]] after reception of a [[Delete]]-command to
    * instruct the log to physically delete logically deleted events that are alreday replicated.

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
@@ -607,18 +607,6 @@ abstract class EventLog[A <: EventLogState](id: String) extends Actor with Event
 object EventLog {
 
   /**
-   * Published on the event-stream, when the [[CircuitBreaker]] closes as a write finally
-   * was successful (after n retries).
-   */
-  case class EventLogAvailable(logId: String)
-
-  /**
-   * Published on the event-stream, if the [[CircuitBreaker]] opens due to an error
-   * when writing events after a configured number of retries.
-   */
-  case class EventLogUnavailable(logId: String, initialCause: Throwable)
-
-  /**
    * Periodically sent to an [[EventLog]] after reception of a [[Delete]]-command to
    * instruct the log to physically delete logically deleted events that are alreday replicated.
    * @see DeletionMetadata

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
@@ -53,7 +53,7 @@ object SingleLocationSpecCassandra {
 
     def props(logId: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef], batching: Boolean): Props = {
       val logProps = Props(new TestEventLog(logId, failureSpec, indexProbe)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
-      Props(new CircuitBreaker(logProps, batching))
+      Props(new CircuitBreaker(logProps, batching, logId))
     }
   }
 

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
@@ -53,7 +53,7 @@ object SingleLocationSpecCassandra {
 
     def props(logId: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef], batching: Boolean): Props = {
       val logProps = Props(new TestEventLog(logId, failureSpec, indexProbe)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
-      Props(new CircuitBreaker(logProps, batching, logId))
+      Props(new CircuitBreaker(logProps, batching))
     }
   }
 

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -140,7 +140,7 @@ class CircuitBreakerIntregrationSpecCassandra extends TestKit(ActorSystem("test"
 
   def logProps(logId: String, failureSpec: TestFailureSpec): Props = {
     val logProps = Props(new TestEventLog(logId, failureSpec)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
-    Props(new CircuitBreaker(logProps, batching = true))
+    Props(new CircuitBreaker(logProps, batching = true, logId))
   }
 
   def createLog(failureSpec: TestFailureSpec = this.failureSpec(-1)): Unit = {

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -29,7 +29,6 @@ import com.rbmhtechnology.eventuate.log.cassandra._
 import com.rbmhtechnology.eventuate.utilities.AwaitHelper
 import com.typesafe.config._
 
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -140,7 +139,7 @@ class CircuitBreakerIntregrationSpecCassandra extends TestKit(ActorSystem("test"
 
   def logProps(logId: String, failureSpec: TestFailureSpec): Props = {
     val logProps = Props(new TestEventLog(logId, failureSpec)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
-    Props(new CircuitBreaker(logProps, batching = true, logId))
+    Props(new CircuitBreaker(logProps, batching = true))
   }
 
   def createLog(failureSpec: TestFailureSpec = this.failureSpec(-1)): Unit = {


### PR DESCRIPTION
CircuitBreaker published (Un)Available notifications on the
event-stream whenever it closes or opens. This messages can be used
by monitoring solutions to detect when the event-log is un-/available.