### PR TITLE
Replay from application-defined sequence number

### DIFF
--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedWriter.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedWriter.scala
@@ -89,6 +89,12 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
   private var numPending: Int = 0
 
   /**
+   * Disallow for [[EventsourcedWriter]] and subclasses as event processing progress is determined by `read`
+   * and `readSuccess`.
+   */
+  override final def replayFromSequenceNr: Option[Long] = None
+
+  /**
    * Asynchronously reads an initial value from the target database, usually to obtain information about
    * event processing progress. This method is called during initialization.
    */
@@ -115,7 +121,7 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
    * and can be overridden.
    */
   def readSuccess(result: R): Option[Long] =
-    None
+    replayFromSequenceNr
 
   /**
    * Called with a write result after a `write` operation successfully completes. This method may update

--- a/src/sphinx/code/EventSourcingDoc.scala
+++ b/src/sphinx/code/EventSourcingDoc.scala
@@ -172,6 +172,28 @@ object LoadSnapshot {
   //#
 }
 
+object AppDefinedSeqNr {
+  import akka.actor._
+  import com.rbmhtechnology.eventuate.EventsourcedActor
+
+  //#replay-from-sequence-nr
+  class CustomRecoveryExampleActor(snr: Long) extends EventsourcedActor {
+
+    override def replayFromSequenceNr: Option[Long] = Some(snr)
+
+    // ...
+    //#
+
+    override def id: String = ???
+    override def eventLog: ActorRef = ???
+    override def onCommand: Receive = ???
+    override def onEvent: Receive = ???
+
+  //#replay-from-sequence-nr
+  }
+  //#
+}
+
 object BatchReplay {
   import akka.actor._
   import com.rbmhtechnology.eventuate.EventsourcedActor

--- a/src/sphinx/reference/event-sourcing.rst
+++ b/src/sphinx/reference/event-sourcing.rst
@@ -189,6 +189,13 @@ Event-sourced components can override the configured default value by overriding
 
 .. _snapshots:
 
+Recovery using an application-defined log sequence number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In order to keep recovery times small it is almost always sensible to recover using snapshots. However, in some very rare cases an event-sourced actor or view can recover quickly using an application-defined log sequence number. If defined, only events with a sequence number equal to or larger than the given sequence number are replayed.
+
+.. includecode:: ../code/EventSourcingDoc.scala
+   :snippet: replay-from-sequence-nr
+
 Snapshots
 ---------
 


### PR DESCRIPTION
We have a use-case in which we want to speed up recovery and minimize snapshot size (currently it is around 700mb, its size being determined by the days of transaction history being kept in memory).

To minimize the snapshot size and reduce the replay duration the actor memorizes before which point in time (= log sequence number) historical data "can be forgotten". The log sequence number is therefore persisted as (part of) its snapshot. The "forgotten data" does therefore not need to be replayed during recovery, reducing replay/recovery (down)time.