### PR TITLE
implement per-eventlog cassandra settings

### DIFF
--- a/eventuate-adapter-spark/src/it/scala/com/rbmhtechnology/eventuate/adapter/spark/SparkBatchAdapterSpec.scala
+++ b/eventuate-adapter-spark/src/it/scala/com/rbmhtechnology/eventuate/adapter/spark/SparkBatchAdapterSpec.scala
@@ -18,22 +18,20 @@ package com.rbmhtechnology.eventuate.adapter.spark
 
 import akka.actor._
 import akka.testkit._
-
 import com.rbmhtechnology.eventuate._
 import com.rbmhtechnology.eventuate.utilities._
 import com.rbmhtechnology.eventuate.log.EventLogWriter
-import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLogSettings
-
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraSettings
 import org.apache.spark._
 import org.scalatest._
 
 class SparkBatchAdapterSpec extends TestKit(ActorSystem("test")) with WordSpecLike with Matchers with SingleLocationSpecCassandraAdapter {
-  val cassandraSettings = new CassandraEventLogSettings(system.settings.config)
+  val cassandraSettings = new CassandraSettings(system.settings.config)
   val sparkConfig = new SparkConf(true)
     .set("spark.cassandra.connection.host", cassandraSettings.contactPoints.head.getHostName)
     .set("spark.cassandra.connection.port", cassandraSettings.contactPoints.head.getPort.toString)
-    .set("spark.cassandra.auth.username", system.settings.config.getString("eventuate.log.cassandra.username"))
-    .set("spark.cassandra.auth.password", system.settings.config.getString("eventuate.log.cassandra.password"))
+    .set("spark.cassandra.auth.username", system.settings.config.getString("eventuate.cassandra.username"))
+    .set("spark.cassandra.auth.password", system.settings.config.getString("eventuate.cassandra.password"))
     .setAppName("adapter")
     .setMaster("local[4]")
 

--- a/eventuate-adapter-spark/src/main/scala/com/rbmhtechnology/eventuate/adapter/spark/SparkBatchAdapter.scala
+++ b/eventuate-adapter-spark/src/main/scala/com/rbmhtechnology/eventuate/adapter/spark/SparkBatchAdapter.scala
@@ -18,13 +18,11 @@ package com.rbmhtechnology.eventuate.adapter.spark
 
 import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
-
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.types._
 import com.rbmhtechnology.eventuate.DurableEvent
-import com.rbmhtechnology.eventuate.log.cassandra.CassandraEventLogSettings
+import com.rbmhtechnology.eventuate.log.cassandra.CassandraSettings
 import com.typesafe.config._
-
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -44,7 +42,7 @@ import org.apache.spark.rdd.RDD
  */
 class SparkBatchAdapter(val context: SparkContext, val config: Config) {
   private val cassandraSettings =
-    new CassandraEventLogSettings(config)
+    new CassandraSettings(config)
 
   private implicit val converter: DurableEventConverter =
     new DurableEventConverter(ConfigFactory.parseString("""akka.actor.provider = "akka.actor.LocalActorRefProvider"""").withFallback(config))

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/LocationSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/LocationSpec.scala
@@ -121,6 +121,7 @@ object MultiLocationConfig {
          |akka.loglevel = "ERROR"
          |
          |eventuate.log.write-batch-size = 3
+         |eventuate.log.cassandra.write-batch-size = 3
          |eventuate.log.replication.retry-delay = 1s
          |eventuate.log.replication.remote-read-timeout = 1s
          |eventuate.log.replication.failure-detection-limit = 3s

--- a/eventuate-core/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationThroughputSpec.scala
+++ b/eventuate-core/src/multi-jvm/scala/com/rbmhtechnology/eventuate/BasicReplicationThroughputSpec.scala
@@ -38,6 +38,7 @@ class BasicReplicationThroughputConfig(providerConfig: Config) extends MultiNode
     s"""
       |akka.remote.netty.tcp.maximum-frame-size = 1048576b
       |eventuate.log.write-batch-size = 2000
+      |eventuate.log.cassandra.write-batch-size = 2000
       |eventuate.log.replication.retry-delay = 10s
     """.stripMargin)
 

--- a/eventuate-core/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
+++ b/eventuate-core/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeReplicationConfig.scala
@@ -28,6 +28,7 @@ trait MultiNodeReplicationConfig extends MultiNodeConfig {
          |akka.loglevel = "ERROR"
          |
          |eventuate.log.write-batch-size = 3
+         |eventuate.log.cassandra.write-batch-size = 3
          |eventuate.log.replication.retry-delay = 1s
          |eventuate.log.replication.failure-detection-limit = 60s
          |

--- a/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedActorSpec.scala
+++ b/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/EventsourcedActorSpec.scala
@@ -32,7 +32,10 @@ import scala.util._
 object EventsourcedActorSpec {
   import EventsourcedViewSpec._
 
-  val config = ConfigFactory.parseString("eventuate.log.write-timeout = 1s")
+  val config = ConfigFactory.parseString(s"""
+    |eventuate.log.write-timeout = 1s
+    |eventuate.log.cassandra.write-timeout = 1s
+  """.stripMargin)
   val timeout = 0.2.seconds
 
   case class Cmd(payload: Any, num: Int = 1)

--- a/eventuate-log-cassandra/src/it/resources/application.conf
+++ b/eventuate-log-cassandra/src/it/resources/application.conf
@@ -1,6 +1,6 @@
 akka.loglevel = "ERROR"
 akka.test.single-expect-default = 20s
 
-eventuate.log.cassandra.default-port = 9142
+eventuate.cassandra.default-port = 9142
 eventuate.log.cassandra.index-update-limit = 100
 eventuate.snapshot.filesystem.dir = target/test-snapshot

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
@@ -74,7 +74,7 @@ object SingleLocationSpecCassandra {
       indexProbe.foreach(_ ! event)
   }
 
-  class TestIndexStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraIndexStore(cassandra, logId) {
+  class TestIndexStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraIndexStore(cassandra, cassandra.settings, logId) {
     private var writeIncrementFailed = false
     private var readClockFailed = false
 

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
@@ -68,13 +68,13 @@ object SingleLocationSpecCassandra {
     }
 
     private[eventuate] override def createIndexStore(cassandra: Cassandra, logId: String) =
-      new TestIndexStore(cassandra, logId, failureSpec)
+      new TestIndexStore(cassandra, logId, settings, failureSpec)
 
     private[eventuate] override def onIndexEvent(event: Any): Unit =
       indexProbe.foreach(_ ! event)
   }
 
-  class TestIndexStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraIndexStore(cassandra, cassandra.settings, logId) {
+  class TestIndexStore(cassandra: Cassandra, logId: String, settings: CassandraEventLogSettings, failureSpec: TestFailureSpec) extends CassandraIndexStore(cassandra, settings, logId) {
     private var writeIncrementFailed = false
     private var readClockFailed = false
 
@@ -144,7 +144,7 @@ trait MultiLocationSpecCassandra extends MultiLocationSpec with LocationCleanupC
 
   override val providerConfig = ConfigFactory.parseString(
     s"""
-       |eventuate.log.cassandra.default-port = 9142
+       |eventuate.cassandra.default-port = 9142
        |eventuate.log.cassandra.index-update-limit = 3
      """.stripMargin)
 

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -45,9 +45,9 @@ object CircuitBreakerIntregrationSpecCassandra {
       |akka.loglevel = "ERROR"
       |akka.test.single-expect-default = 20s
       |
+      |eventuate.cassandra.default-port = 9142
       |eventuate.log.circuit-breaker.open-after-retries = 2
       |eventuate.log.cassandra.write-retry-max = 3
-      |eventuate.log.cassandra.default-port = 9142
       |eventuate.log.cassandra.index-update-limit = 3
       |eventuate.log.cassandra.init-retry-delay = 1s
       |eventuate.snapshot.filesystem.dir = target/test-snapshot
@@ -60,10 +60,10 @@ object CircuitBreakerIntregrationSpecCassandra {
 
   class TestEventLog(id: String, failureSpec: TestFailureSpec) extends CassandraEventLog(id) {
     override private[eventuate] def createEventLogStore(cassandra: Cassandra, logId: String) =
-      new TestEventLogStore(cassandra, logId, failureSpec)
+      new TestEventLogStore(cassandra, logId, settings, failureSpec)
   }
 
-  class TestEventLogStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraEventLogStore(cassandra, cassandra.settings, logId) {
+  class TestEventLogStore(cassandra: Cassandra, logId: String, settings: CassandraEventLogSettings, failureSpec: TestFailureSpec) extends CassandraEventLogStore(cassandra, settings, logId) {
     import failureSpec._
 
     var numAttempts = 0

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -63,7 +63,7 @@ object CircuitBreakerIntregrationSpecCassandra {
       new TestEventLogStore(cassandra, logId, failureSpec)
   }
 
-  class TestEventLogStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraEventLogStore(cassandra, logId) {
+  class TestEventLogStore(cassandra: Cassandra, logId: String, failureSpec: TestFailureSpec) extends CassandraEventLogStore(cassandra, cassandra.settings, logId) {
     import failureSpec._
 
     var numAttempts = 0

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogPartitioningSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogPartitioningSpecCassandra.scala
@@ -33,9 +33,9 @@ object EventLogPartitioningSpecCassandra {
       |
       |eventuate.snapshot.filesystem.dir = target/test-snapshot
       |
-      |eventuate.log.write-batch-size = 3
+      |eventuate.cassandra.default-port = 9142
+      |eventuate.log.cassandra.write-batch-size = 3
       |eventuate.log.cassandra.partition-size = 5
-      |eventuate.log.cassandra.default-port = 9142
     """.stripMargin)
 }
 

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
@@ -33,7 +33,7 @@ import com.typesafe.config._
 object EventLogSpecCassandra {
   val config: Config = ConfigFactory.parseString(
     """
-      |eventuate.log.cassandra.default-port = 9142
+      |eventuate.cassandra.default-port = 9142
       |eventuate.log.cassandra.index-update-limit = 3
       |eventuate.log.cassandra.init-retry-delay = 1s
     """.stripMargin).withFallback(EventLogSpec.config)

--- a/eventuate-log-cassandra/src/main/resources/reference.conf
+++ b/eventuate-log-cassandra/src/main/resources/reference.conf
@@ -1,5 +1,6 @@
 eventuate {
-  log.cassandra {
+  # This section contains all cluster-wide configuration values.
+  cassandra {
     # Comma-separated list of contact points in the cluster (comma-separated
     # hostname or hostname:port list).
     contact-points = ["127.0.0.1"]
@@ -26,16 +27,47 @@ eventuate {
     # Replication factor to use when creating the keyspace.
     replication-factor = 1
 
+    # Write consistency level
+    write-consistency = "QUORUM"
+
+    # Read consistency level
+    read-consistency = "QUORUM"
+
+    # Maximum number of initial connection retries to a Cassandra cluster.
+    connect-retry-max = 3
+
+    # Delay between initial connection retries to a Cassandra cluster.
+    connect-retry-delay = 5s
+  }
+
+  # Below you can configure the default cassandra event log settings. You can
+  # override these values on a per-eventlog level using the config section:
+  #   'eventuate.log.cassandra.<log-id>'
+  log.cassandra {
     # Maximum number of times a failed write should be retried until the event
     # log actor gives up and stops itself. The delay between write retries can
     # be configured with eventuate.log.write-timeout.
     write-retry-max = 65536
 
     # Write consistency level
-    write-consistency = "QUORUM"
+    write-consistency = ${eventuate.cassandra.write-consistency}
 
     # Read consistency level
-    read-consistency = "QUORUM"
+    read-consistency = ${eventuate.cassandra.read-consistency}
+
+    # Timeout for write operations to a local event log. These are batch
+    # event writes made by event-sourced processors and replicators. This
+    # timeout does not apply to event-sourced actor writes.
+    write-timeout = ${eventuate.log.write-timeout}
+
+    # Target batch size for writing events. It is used by the batching layer
+    # to limit the size of event batches to be written atomically to an event
+    # log. It also limits the size of event batches replicated from remote
+    # source logs and to a local target log. Please note that this is not
+    # a strict batch size limit. Event-sourced actors can still emit batches
+    # of larger size (although it is very uncommon to emit that many events
+    # per command).
+    write-batch-size = ${eventuate.log.write-batch-size}
 
     # Maximum number of events stored per event log partition. Must be greater
     # than eventuate.log.write-batch-size.
@@ -54,12 +86,6 @@ eventuate {
     # recovery of the current sequence number and version vector as well as
     # indexing of not yet indexed log entries.
     init-retry-delay = 5s
-
-    # Maximum number of initial connection retries to a Cassandra cluster.
-    connect-retry-max = 3
-
-    # Delay between initial connection retries to a Cassandra cluster.
-    connect-retry-delay = 5s
   }
 
   log.dispatchers {

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
@@ -104,7 +104,7 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
    * Settings used by the Cassandra storage backend. Closed when the `ActorSystem` of
    * this extension terminates.
    */
-  private[eventuate] val settings = new CassandraEventLogSettings(system.settings.config)
+  private[eventuate] val settings = new CassandraSettings(system.settings.config)
 
   /**
    * Serializer used by the Cassandra storage backend. Closed when the `ActorSystem` of
@@ -115,7 +115,7 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
   private val logging = Logging(system, this)
   private val statements = new CassandraEventStatements with CassandraAggregateEventStatements with CassandraEventLogClockStatements with CassandraReplicationProgressStatements with CassandraDeletedToStatements {
 
-    override def settings: CassandraEventLogSettings =
+    override def settings: CassandraSettings =
       extension.settings
   }
 
@@ -182,14 +182,14 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
   private[eventuate] def prepareWriteEvent(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
     session.prepare(writeEventStatement(logId)).setConsistencyLevel(settings.writeConsistency)
 
-  private[eventuate] def prepareReadEvents(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
-    session.prepare(readEventsStatement(logId)).setConsistencyLevel(settings.readConsistency)
+  private[eventuate] def prepareReadEvents(logId: String, settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(readEventsStatement(logId, settings)).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] def prepareWriteAggregateEvent(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
     session.prepare(writeAggregateEventStatement(logId)).setConsistencyLevel(settings.writeConsistency)
 
-  private[eventuate] def prepareReadAggregateEvents(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
-    session.prepare(readAggregateEventsStatement(logId)).setConsistencyLevel(settings.readConsistency)
+  private[eventuate] def prepareReadAggregateEvents(logId: String, settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(readAggregateEventsStatement(logId, settings)).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] val preparedWriteEventLogClockStatement: PreparedStatement =
     session.prepare(writeEventLogClockStatement).setConsistencyLevel(settings.writeConsistency)

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/Cassandra.scala
@@ -119,7 +119,6 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
       extension.settings
   }
 
-  import settings._
   import statements._
 
   private var _session: Session = _
@@ -127,7 +126,7 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
   Try {
     _session = connect()
 
-    if (keyspaceAutoCreate)
+    if (settings.keyspaceAutoCreate)
       _session.execute(createKeySpaceStatement)
 
     _session.execute(createEventLogClockTableStatement)
@@ -146,7 +145,7 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
     val curAttempt = retries + 1
     val maxAttempts = settings.connectRetryMax + 1
 
-    Try(clusterBuilder.build().connect()) match {
+    Try(settings.clusterBuilder.build().connect()) match {
       case Failure(e: NoHostAvailableException) if retries < settings.connectRetryMax =>
         logging.error(e, s"Cannot connect to cluster (attempt ${curAttempt}/${maxAttempts} ...)")
         Thread.sleep(settings.connectRetryDelay.toMillis)
@@ -180,38 +179,38 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
   private[eventuate] def createAggregateEventTable(logId: String): Unit =
     session.execute(createAggregateEventTableStatement(logId))
 
-  private[eventuate] def prepareWriteEvent(logId: String): PreparedStatement =
-    session.prepare(writeEventStatement(logId)).setConsistencyLevel(writeConsistency)
+  private[eventuate] def prepareWriteEvent(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(writeEventStatement(logId)).setConsistencyLevel(settings.writeConsistency)
 
-  private[eventuate] def prepareReadEvents(logId: String): PreparedStatement =
-    session.prepare(readEventsStatement(logId)).setConsistencyLevel(readConsistency)
+  private[eventuate] def prepareReadEvents(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(readEventsStatement(logId)).setConsistencyLevel(settings.readConsistency)
 
-  private[eventuate] def prepareWriteAggregateEvent(logId: String): PreparedStatement =
-    session.prepare(writeAggregateEventStatement(logId)).setConsistencyLevel(writeConsistency)
+  private[eventuate] def prepareWriteAggregateEvent(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(writeAggregateEventStatement(logId)).setConsistencyLevel(settings.writeConsistency)
 
-  private[eventuate] def prepareReadAggregateEvents(logId: String): PreparedStatement =
-    session.prepare(readAggregateEventsStatement(logId)).setConsistencyLevel(readConsistency)
+  private[eventuate] def prepareReadAggregateEvents(logId: String)(implicit settings: CassandraEventLogSettings): PreparedStatement =
+    session.prepare(readAggregateEventsStatement(logId)).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] val preparedWriteEventLogClockStatement: PreparedStatement =
-    session.prepare(writeEventLogClockStatement).setConsistencyLevel(writeConsistency)
+    session.prepare(writeEventLogClockStatement).setConsistencyLevel(settings.writeConsistency)
 
   private[eventuate] val preparedReadEventLogClockStatement: PreparedStatement =
-    session.prepare(readEventLogClockStatement).setConsistencyLevel(readConsistency)
+    session.prepare(readEventLogClockStatement).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] val preparedWriteReplicationProgressStatement: PreparedStatement =
-    session.prepare(writeReplicationProgressStatement).setConsistencyLevel(writeConsistency)
+    session.prepare(writeReplicationProgressStatement).setConsistencyLevel(settings.writeConsistency)
 
   private[eventuate] val preparedReadReplicationProgressesStatement: PreparedStatement =
-    session.prepare(readReplicationProgressesStatement).setConsistencyLevel(readConsistency)
+    session.prepare(readReplicationProgressesStatement).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] val preparedReadReplicationProgressStatement: PreparedStatement =
-    session.prepare(readReplicationProgressStatement).setConsistencyLevel(readConsistency)
+    session.prepare(readReplicationProgressStatement).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] val preparedWriteDeletedToStatement: PreparedStatement =
-    session.prepare(writeDeletedToStatement).setConsistencyLevel(writeConsistency)
+    session.prepare(writeDeletedToStatement).setConsistencyLevel(settings.writeConsistency)
 
   private[eventuate] val preparedReadDeletedToStatement: PreparedStatement =
-    session.prepare(readDeletedToStatement).setConsistencyLevel(readConsistency)
+    session.prepare(readDeletedToStatement).setConsistencyLevel(settings.readConsistency)
 
   private[eventuate] def eventToByteBuffer(event: DurableEvent): ByteBuffer =
     ByteBuffer.wrap(serializer.serialize(event).get)
@@ -228,14 +227,14 @@ class Cassandra(val system: ExtendedActorSystem) extends Extension { extension =
   private[eventuate] def execute(statement: Statement, timeout: Long): Unit =
     session.executeAsync(statement).getUninterruptibly(timeout, TimeUnit.MILLISECONDS)
 
-  private[eventuate] def executeBatch(body: BatchStatement => Unit): Unit =
+  private[eventuate] def executeBatch(body: BatchStatement => Unit)(implicit settings: CassandraEventLogSettings): Unit =
     execute(withBatch(body), settings.writeTimeout)
 
-  private[eventuate] def executeBatchAsync(body: BatchStatement => Unit)(implicit executor: ExecutionContext): Future[Unit] =
+  private[eventuate] def executeBatchAsync(body: BatchStatement => Unit)(implicit executor: ExecutionContext, settings: CassandraEventLogSettings): Future[Unit] =
     session.executeAsync(withBatch(body)).map(_ => ())
 
-  private def withBatch(body: BatchStatement => Unit): BatchStatement = {
-    val batch = new BatchStatement().setConsistencyLevel(writeConsistency).asInstanceOf[BatchStatement]
+  private def withBatch(body: BatchStatement => Unit)(implicit settings: CassandraEventLogSettings): BatchStatement = {
+    val batch = new BatchStatement().setConsistencyLevel(settings.writeConsistency).asInstanceOf[BatchStatement]
     body(batch)
     batch
   }

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraDeletedToStore.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraDeletedToStore.scala
@@ -21,10 +21,10 @@ import java.lang.{ Long => JLong }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-private[eventuate] class CassandraDeletedToStore(cassandra: Cassandra, logId: String) {
+private[eventuate] class CassandraDeletedToStore(cassandra: Cassandra, settings: CassandraEventLogSettings, logId: String) {
 
   def writeDeletedTo(deletedTo: Long): Unit =
-    cassandra.execute(cassandra.preparedWriteDeletedToStatement.bind(logId, deletedTo: JLong), cassandra.settings.writeTimeout)
+    cassandra.execute(cassandra.preparedWriteDeletedToStatement.bind(logId, deletedTo: JLong), settings.writeTimeout)
 
   def readDeletedToAsync(implicit executor: ExecutionContext): Future[Long] = {
     cassandra.session.executeAsync(cassandra.preparedReadDeletedToStatement.bind(logId)).map { resultSet =>

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
@@ -154,12 +154,12 @@ class CassandraEventLog(id: String) extends EventLog[CassandraEventLogState](id)
       case Failure(e: QueryExecutionException) =>
         context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed - retry in ${settings.writeTimeout} ms")
-        Thread.sleep(cassandra.settings.writeTimeout)
+        Thread.sleep(settings.writeTimeout)
         writeRetry(events, partition, clock, num + 1)
       case Failure(e: NoHostAvailableException) =>
         context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed - retry in ${settings.writeTimeout} ms")
-        Thread.sleep(cassandra.settings.writeTimeout)
+        Thread.sleep(settings.writeTimeout)
         writeRetry(events, partition, clock, num + 1)
       case Failure(e) =>
         logger.error(e, s"write attempt ${num} failed - stop self")

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogSettings.scala
@@ -16,136 +16,57 @@
 
 package com.rbmhtechnology.eventuate.log.cassandra
 
-import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
 
 import akka.util.Helpers.Requiring
-
-import com.datastax.driver.core.{ Cluster, ConsistencyLevel }
+import com.datastax.driver.core.ConsistencyLevel
 import com.typesafe.config.Config
-
 import com.rbmhtechnology.eventuate.log._
 
-import scala.collection.JavaConverters._
-import scala.concurrent.duration._
-
-class CassandraEventLogSpecificSettings(config: Config, eventlog: String)
-  extends CassandraEventLogSettings(config) {
-  import CassandraEventLogSettings._
-
-  private val getLong = get(config.getLong) _
-  private val getInt = get(config.getInt) _
-  private val getConsistency = get(key => ConsistencyLevel.valueOf(config.getString(key))) _
-  private val getMilliseconds = get(key => config.getDuration(key, TimeUnit.MILLISECONDS)) _
-
-  override val writeBatchSize: Int =
-    getInt(WriteBatchSize, super.writeBatchSize)
-
-  override val writeTimeout: Long =
-    getMilliseconds(WriteTimeout, super.writeTimeout)
-
-  override val partitionSize: Long =
-    getLong(CassandraPartitionSize, super.partitionSize)
-
-  override val writeRetryMax: Int =
-    getInt(CassandraWriteRetryMax, super.writeRetryMax)
-
-  override val readConsistency: ConsistencyLevel =
-    getConsistency(CassandraReadConsistency, super.readConsistency)
-
-  override val writeConsistency: ConsistencyLevel =
-    getConsistency(CassandraWriteConsistency, super.writeConsistency)
-
-  private def get[T](getter: String => T)(key: String, fallback: => T): T = {
-    val settingKey = s"eventuate.log.eventlog.$eventlog.$key"
-    if (config.hasPath(settingKey)) getter(settingKey) else fallback
-  }
-}
+import scala.concurrent.duration.{ DurationLong, FiniteDuration }
 
 class CassandraEventLogSettings(config: Config) extends EventLogSettings {
   import CassandraEventLogSettings._
 
   def writeTimeout: Long =
-    config.getDuration(s"eventuate.log.$WriteTimeout", TimeUnit.MILLISECONDS)
+    config.getDuration(WriteTimeout, TimeUnit.MILLISECONDS)
 
   def writeBatchSize: Int =
-    config.getInt(s"eventuate.log.$WriteBatchSize")
+    config.getInt(WriteBatchSize)
 
   def readConsistency: ConsistencyLevel =
-    ConsistencyLevel.valueOf(config.getString(s"eventuate.log.$CassandraReadConsistency"))
+    ConsistencyLevel.valueOf(config.getString(CassandraSettings.CassandraReadConsistency))
 
   def writeConsistency: ConsistencyLevel =
-    ConsistencyLevel.valueOf(config.getString(s"eventuate.log.$CassandraWriteConsistency"))
+    ConsistencyLevel.valueOf(config.getString(CassandraSettings.CassandraWriteConsistency))
 
   def writeRetryMax: Int =
-    config.getInt(s"eventuate.log.$CassandraWriteRetryMax")
+    config.getInt(CassandraWriteRetryMax)
 
   override def partitionSize: Long =
-    config.getLong(s"eventuate.log.$CassandraPartitionSize")
+    config.getLong(CassandraPartitionSize)
       .requiring(_ > writeBatchSize,
-        s"eventuate.log.cassandra.partition-size must be greater than eventuate.log.write-batch-size (${writeBatchSize})")
-
-  val keyspace: String =
-    config.getString("eventuate.log.cassandra.keyspace")
-
-  val keyspaceAutoCreate: Boolean =
-    config.getBoolean("eventuate.log.cassandra.keyspace-autocreate")
-
-  val replicationFactor: Int =
-    config.getInt("eventuate.log.cassandra.replication-factor")
-
-  val tablePrefix: String =
-    config.getString("eventuate.log.cassandra.table-prefix")
-
-  val defaultPort: Int =
-    config.getInt("eventuate.log.cassandra.default-port")
-
-  val contactPoints =
-    getContactPoints(config.getStringList("eventuate.log.cassandra.contact-points").asScala, defaultPort)
+        s"partition-size must be greater than write-batch-size ($writeBatchSize)")
 
   val indexUpdateLimit: Int =
-    config.getInt("eventuate.log.cassandra.index-update-limit")
+    config.getInt(IndexUpdateLimit)
 
   val initRetryMax: Int =
-    config.getInt("eventuate.log.cassandra.init-retry-max")
+    config.getInt(InitRetryMax)
 
   val initRetryDelay: FiniteDuration =
-    config.getDuration("eventuate.log.cassandra.init-retry-delay", TimeUnit.MILLISECONDS).millis
+    config.getDuration(InitRetryDelay, TimeUnit.MILLISECONDS).millis
 
   def deletionRetryDelay: FiniteDuration =
     ???
-
-  val connectRetryMax: Int =
-    config.getInt("eventuate.log.cassandra.connect-retry-max")
-
-  val connectRetryDelay: FiniteDuration =
-    config.getDuration("eventuate.log.cassandra.connect-retry-delay", TimeUnit.MILLISECONDS).millis
-
-  val clusterBuilder: Cluster.Builder =
-    Cluster.builder.addContactPointsWithPorts(contactPoints.asJava).withCredentials(
-      config.getString("eventuate.log.cassandra.username"),
-      config.getString("eventuate.log.cassandra.password"))
 }
 
-private object CassandraEventLogSettings {
+object CassandraEventLogSettings {
   val WriteBatchSize = "write-batch-size"
   val WriteTimeout = "write-timeout"
-  val CassandraPartitionSize = "cassandra.partition-size"
-  val CassandraWriteRetryMax = "cassandra.write-retry-max"
-  val CassandraReadConsistency = "cassandra.read-consistency"
-  val CassandraWriteConsistency = "cassandra.write-consistency"
-
-  def getContactPoints(contactPoints: Seq[String], defaultPort: Int): Seq[InetSocketAddress] = {
-    contactPoints match {
-      case null | Nil => throw new IllegalArgumentException("a contact point list cannot be empty.")
-      case hosts => hosts map {
-        ipWithPort =>
-          ipWithPort.split(":") match {
-            case Array(host, port) => new InetSocketAddress(host, port.toInt)
-            case Array(host)       => new InetSocketAddress(host, defaultPort)
-            case msg               => throw new IllegalArgumentException(s"a contact point should have the form [host:port] or [host] but was: $msg.")
-          }
-      }
-    }
-  }
+  val CassandraPartitionSize = "partition-size"
+  val CassandraWriteRetryMax = "write-retry-max"
+  val InitRetryMax = "init-retry-max"
+  val InitRetryDelay = "init-retry-delay"
+  val IndexUpdateLimit = "index-update-limit"
 }

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogStore.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogStore.scala
@@ -32,7 +32,7 @@ private[eventuate] class CassandraEventLogStore(cassandra: Cassandra, implicit v
     cassandra.prepareWriteEvent(logId)
 
   val preparedReadEventsStatement: PreparedStatement =
-    cassandra.prepareReadEvents(logId)
+    cassandra.prepareReadEvents(logId, settings)
 
   def write(events: Seq[DurableEvent], partition: Long) =
     cassandra.executeBatch { batch =>

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogStore.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLogStore.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.{ VectorBuilder, Seq }
 import scala.concurrent.{ ExecutionContext, Future }
 
-private[eventuate] class CassandraEventLogStore(cassandra: Cassandra, logId: String) {
+private[eventuate] class CassandraEventLogStore(cassandra: Cassandra, implicit val settings: CassandraEventLogSettings, logId: String) {
   val preparedWriteEventStatement: PreparedStatement =
     cassandra.prepareWriteEvent(logId)
 
@@ -71,7 +71,7 @@ private[eventuate] class CassandraEventLogStore(cassandra: Cassandra, logId: Str
     new EventIterator(fromSequenceNr, toSequenceNr, fetchSize)
 
   private class EventIterator(fromSequenceNr: Long, toSequenceNr: Long, fetchSize: Int) extends Iterator[DurableEvent] with Closeable {
-    import cassandra.settings._
+    import settings._
     import EventLog._
 
     var currentSequenceNr = math.max(fromSequenceNr, 1L)

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndexStore.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndexStore.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent._
 
-private[eventuate] class CassandraIndexStore(cassandra: Cassandra, logId: String) {
+private[eventuate] class CassandraIndexStore(cassandra: Cassandra, implicit val settings: CassandraEventLogSettings, logId: String) {
   import CassandraIndex._
 
   private val preparedReadAggregateEventStatement: PreparedStatement = cassandra.prepareReadAggregateEvents(logId)
@@ -75,7 +75,7 @@ private[eventuate] class CassandraIndexStore(cassandra: Cassandra, logId: String
     final def hasNext: Boolean = {
       if (currentIter.hasNext) {
         true
-      } else if (rowCount < cassandra.settings.partitionSize) {
+      } else if (rowCount < settings.partitionSize) {
         // all events consumed
         false
       } else {

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndexStore.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraIndexStore.scala
@@ -30,7 +30,7 @@ import scala.concurrent._
 private[eventuate] class CassandraIndexStore(cassandra: Cassandra, implicit val settings: CassandraEventLogSettings, logId: String) {
   import CassandraIndex._
 
-  private val preparedReadAggregateEventStatement: PreparedStatement = cassandra.prepareReadAggregateEvents(logId)
+  private val preparedReadAggregateEventStatement: PreparedStatement = cassandra.prepareReadAggregateEvents(logId, settings)
   private val preparedWriteAggregateEventStatement: PreparedStatement = cassandra.prepareWriteAggregateEvent(logId)
 
   def readEventLogClockSnapshotAsync(implicit executor: ExecutionContext): Future[EventLogClock] =

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraSettings.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraSettings.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.log.cassandra
+
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+import com.datastax.driver.core.{ Cluster, ConsistencyLevel }
+import com.typesafe.config.Config
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationLong
+import scala.concurrent.duration.FiniteDuration
+
+case class CassandraSettings(config: Config) {
+  import CassandraSettings._
+
+  val keyspace: String =
+    config.getString("eventuate.cassandra.keyspace")
+
+  val keyspaceAutoCreate: Boolean =
+    config.getBoolean("eventuate.cassandra.keyspace-autocreate")
+
+  val replicationFactor: Int =
+    config.getInt("eventuate.cassandra.replication-factor")
+
+  val tablePrefix: String =
+    config.getString("eventuate.cassandra.table-prefix")
+
+  val defaultPort: Int =
+    config.getInt("eventuate.cassandra.default-port")
+
+  val contactPoints =
+    getContactPoints(config.getStringList("eventuate.cassandra.contact-points").asScala, defaultPort)
+
+  def readConsistency: ConsistencyLevel =
+    ConsistencyLevel.valueOf(config.getString(s"eventuate.cassandra.${CassandraReadConsistency}"))
+
+  def writeConsistency: ConsistencyLevel =
+    ConsistencyLevel.valueOf(config.getString(s"eventuate.cassandra.${CassandraWriteConsistency}"))
+
+  val connectRetryMax: Int =
+    config.getInt("eventuate.cassandra.connect-retry-max")
+
+  val connectRetryDelay: FiniteDuration =
+    config.getDuration("eventuate.cassandra.connect-retry-delay", TimeUnit.MILLISECONDS).millis
+
+  val clusterBuilder: Cluster.Builder =
+    Cluster.builder.addContactPointsWithPorts(contactPoints.asJava).withCredentials(
+      config.getString("eventuate.cassandra.username"),
+      config.getString("eventuate.cassandra.password"))
+}
+
+private object CassandraSettings {
+  val CassandraReadConsistency = "read-consistency"
+  val CassandraWriteConsistency = "write-consistency"
+
+  def getContactPoints(contactPoints: Seq[String], defaultPort: Int): Seq[InetSocketAddress] = {
+    contactPoints match {
+      case null | Nil => throw new IllegalArgumentException("a contact point list cannot be empty.")
+      case hosts => hosts map {
+        ipWithPort =>
+          ipWithPort.split(":") match {
+            case Array(host, port) => new InetSocketAddress(host, port.toInt)
+            case Array(host)       => new InetSocketAddress(host, defaultPort)
+            case msg               => throw new IllegalArgumentException(s"a contact point should have the form [host:port] or [host] but was: $msg.")
+          }
+      }
+    }
+  }
+}

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraStatements.scala
@@ -17,7 +17,7 @@
 package com.rbmhtechnology.eventuate.log.cassandra
 
 private[eventuate] trait CassandraStatements {
-  def settings: CassandraEventLogSettings
+  def settings: CassandraSettings
 
   def createKeySpaceStatement = s"""
       CREATE KEYSPACE IF NOT EXISTS ${settings.keyspace}
@@ -43,7 +43,7 @@ private[eventuate] trait CassandraEventStatements extends CassandraStatements {
       VALUES (?, ?, ?)
     """
 
-  def readEventsStatement(logId: String) = s"""
+  def readEventsStatement(logId: String, settings: CassandraEventLogSettings) = s"""
       SELECT * FROM ${eventTable(logId)} WHERE
         partition_nr = ? AND
         sequence_nr >= ? AND
@@ -69,7 +69,7 @@ private[eventuate] trait CassandraAggregateEventStatements extends CassandraStat
       VALUES (?, ?, ?)
     """
 
-  def readAggregateEventsStatement(logId: String) = s"""
+  def readAggregateEventsStatement(logId: String, settings: CassandraEventLogSettings) = s"""
       SELECT * FROM ${aggregateEventTable(logId)} WHERE
         aggregate_id = ? AND
         sequence_nr >= ? AND

--- a/eventuate-log-cassandra/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeConfigCassandra.scala
+++ b/eventuate-log-cassandra/src/multi-jvm/scala/com/rbmhtechnology/eventuate/MultiNodeConfigCassandra.scala
@@ -21,7 +21,7 @@ import com.typesafe.config._
 object MultiNodeConfigCassandra {
   val providerConfig: Config = ConfigFactory.parseString(
     s"""
-       |eventuate.log.cassandra.default-port = 9142
+       |eventuate.cassandra.default-port = 9142
        |eventuate.log.cassandra.index-update-limit = 3
        |eventuate.log.cassandra.table-prefix = mnt
      """.stripMargin)


### PR DESCRIPTION
Hi,

at first I  planned to implement a configurable per-eventlog `partition-size` only in order to cope with heterogenous event sizes across different event logs. Now you can override the  cassandra settings as a whole.

The `CassandraEventLog` constructor and its companion's `props` method
support an optional argument of type `Option[CassandraEventLogSettings]`
to override the 'global' settings of the `Cassandra` extension for a
specific eventlog.

As soon as this is worth integrating we can mention this 'feature' in the appropriate sections in the docs.

Cheers,
Gregor
