### PR TITLE
Make CircuitBreaker publish (Un)Available

### DIFF
--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/CircuitBreaker.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/CircuitBreaker.scala
@@ -17,7 +17,6 @@
 package com.rbmhtechnology.eventuate.log
 
 import akka.actor._
-
 import com.rbmhtechnology.eventuate.EventsourcingProtocol._
 import com.typesafe.config.Config
 
@@ -47,10 +46,13 @@ class CircuitBreaker(logProps: Props, batching: Boolean) extends Actor {
     context.watch(createLog)
 
   private val closed: Receive = {
-    case ServiceInitialized | ServiceNormal =>
+    case serviceFailed: ServiceFailed =>
+      if (serviceFailed.retry >= settings.openAfterRetries) {
+        publish(serviceFailed)
+        context.become(open)
+      }
+    case _: ServiceEvent =>
     // normal operation
-    case ServiceFailed(retry) =>
-      if (retry >= settings.openAfterRetries) context.become(open)
     case Terminated(_) =>
       context.stop(self)
     case msg =>
@@ -58,10 +60,11 @@ class CircuitBreaker(logProps: Props, batching: Boolean) extends Actor {
   }
 
   private val open: Receive = {
-    case ServiceInitialized | ServiceNormal =>
-      context.become(closed)
-    case ServiceFailed(retry) =>
+    case _: ServiceFailed =>
     // failure persists
+    case serviceEvent: ServiceEvent =>
+      publish(serviceEvent)
+      context.become(closed)
     case Terminated(_) =>
       context.stop(self)
     case Write(events, initiator, replyTo, cid, iid) =>
@@ -77,9 +80,12 @@ class CircuitBreaker(logProps: Props, batching: Boolean) extends Actor {
 
   private def createLog(): ActorRef =
     if (batching) context.actorOf(Props(new BatchingLayer(logProps))) else context.actorOf(logProps)
+
+  private def publish(serviceEvent: ServiceEvent): Unit =
+    context.system.eventStream.publish(serviceEvent)
 }
 
-private object CircuitBreaker {
+object CircuitBreaker {
   /**
    * Default [[EventLogUnavailableException]] instance.
    */
@@ -93,17 +99,23 @@ private object CircuitBreaker {
   /**
    * Sent by an event log to indicate that it has been successfully initialized.
    */
-  case object ServiceInitialized extends ServiceEvent
+  case class ServiceInitialized(logId: String) extends ServiceEvent
 
   /**
    * Sent by an event log to indicate that it has successfully written an event batch.
+   *
+   * This is also published on the event-stream when it closes the [[CircuitBreaker]]
+   * (after previous failures that opened the [[CircuitBreaker]]).
    */
-  case object ServiceNormal extends ServiceEvent
+  case class ServiceNormal(logId: String) extends ServiceEvent
 
   /**
    * Sent by an event log to indicate that it failed to write an event batch. The current
    * retry count is given by the `retry` parameter.
+   *
+   * This is also published on the event-stream when it opens the [[CircuitBreaker]],
+   * i.e. when `retry` exceeds a configured limit.
    */
-  case class ServiceFailed(retry: Int) extends ServiceEvent
+  case class ServiceFailed(logId: String, retry: Int, cause: Throwable) extends ServiceEvent
 
 }

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
@@ -605,6 +605,7 @@ abstract class EventLog[A <: EventLogState](id: String) extends Actor with Event
 }
 
 object EventLog {
+
   /**
    * Periodically sent to an [[EventLog]] after reception of a [[Delete]]-command to
    * instruct the log to physically delete logically deleted events that are alreday replicated.

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -29,7 +29,6 @@ import com.rbmhtechnology.eventuate.log.cassandra._
 import com.rbmhtechnology.eventuate.utilities.AwaitHelper
 import com.typesafe.config._
 
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}

--- a/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
+++ b/eventuate-log-cassandra/src/main/scala/com/rbmhtechnology/eventuate/log/cassandra/CassandraEventLog.scala
@@ -104,7 +104,7 @@ class CassandraEventLog(id: String) extends EventLog[CassandraEventLogState](id)
     index = createIndex(cassandra, state.eventLogClockSnapshot, indexStore, eventLogStore, id)
     indexSequenceNr = state.eventLogClockSnapshot.sequenceNr
     updateCount = state.eventLogClock.sequenceNr - indexSequenceNr
-    context.parent ! ServiceInitialized
+    context.parent ! ServiceInitialized(id)
   }
 
   override def readReplicationProgresses: Future[Map[String, Long]] =
@@ -138,26 +138,26 @@ class CassandraEventLog(id: String) extends EventLog[CassandraEventLogState](id)
   private def writeRetry(events: Seq[DurableEvent], partition: Long, clock: EventLogClock, num: Int = 0): Unit = {
     Try(writeBatch(events, partition, clock)) match {
       case Success(r) =>
-        context.parent ! ServiceNormal
+        context.parent ! ServiceNormal(id)
       case Failure(e) if num >= cassandra.settings.writeRetryMax =>
         logger.error(e, s"write attempt ${num} failed: reached maximum number of retries - stop self")
         context.stop(self)
         throw e
       case Failure(e: TimeoutException) =>
-        context.parent ! ServiceFailed(num)
+        context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed: timeout after ${cassandra.settings.writeTimeout} ms - retry now")
         writeRetry(events, partition, clock, num + 1)
       case Failure(e: WriteTimeoutException) =>
-        context.parent ! ServiceFailed(num)
+        context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed - retry now")
         writeRetry(events, partition, clock, num + 1)
       case Failure(e: QueryExecutionException) =>
-        context.parent ! ServiceFailed(num)
+        context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed - retry in ${cassandra.settings.writeTimeout} ms")
         Thread.sleep(cassandra.settings.writeTimeout)
         writeRetry(events, partition, clock, num + 1)
       case Failure(e: NoHostAvailableException) =>
-        context.parent ! ServiceFailed(num)
+        context.parent ! ServiceFailed(id, num, e)
         logger.error(e, s"write attempt ${num} failed - retry in ${cassandra.settings.writeTimeout} ms")
         Thread.sleep(cassandra.settings.writeTimeout)
         writeRetry(events, partition, clock, num + 1)


### PR DESCRIPTION
CircuitBreaker publishes (Un)Available notifications on the
event-stream whenever it closes or opens. This messages can be used
by monitoring solutions to detect when the event-log is un-/available.