### PR TITLE
AbstractEventsourcedProcessorSpec failed

### DIFF
--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/BaseSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/BaseSpec.java
@@ -27,6 +27,7 @@ import com.rbmhtechnology.eventuate.EventsourcingProtocol.ReplaySuccess;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.scalatest.junit.JUnitSuite;
 import scala.Option;
 import scala.collection.immutable.$colon$colon;
 import scala.collection.immutable.List$;
@@ -36,7 +37,7 @@ import scala.collection.immutable.Vector$;
 
 import java.util.Arrays;
 
-public abstract class BaseSpec {
+public abstract class BaseSpec extends JUnitSuite {
 
     @SuppressWarnings("ThrowableInstanceNeverThrown")
     public static final Throwable FAILURE = new NoStackTraceException("failure");

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -60,7 +60,6 @@ object ProjectSettings {
   )
 
   lazy val testSettings: Seq[Setting[_]] = Seq(
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-a"),
     parallelExecution in Test := false,
     fork in Test := true
   )


### PR DESCRIPTION
- fix a race condition in the tests of AbstractEventsourcedProcessor where a test could be influenced by the execution of the previous test
- extend all tests from JUnitSuite for enhanced test result reporting
- remove junit-interface specific test-options due to the usage of JUnitSuite

- closes #230