### PR TITLE
Event-Metadata in Vert.x Adapter

### DIFF
--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/EventMetadataSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/EventMetadataSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.adapter.vertx
+
+import com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata
+import io.vertx.core.MultiMap
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.collection.JavaConverters._
+
+class EventMetadataSpec extends WordSpecLike with MustMatchers  {
+
+  import EventMetadata._
+  import EventMetadata.Headers._
+
+  def headers(elems: (String, Any)*): MultiMap = {
+    val headers = MultiMap.caseInsensitiveMultiMap()
+    headers.setAll(Map(elems: _*).mapValues(_.toString).asJava)
+    headers
+  }
+
+  "An EventMetadata" when {
+    "supplied with valid headers" must {
+      "be instantiated with all metadata" in {
+        val metadata = EventMetadata.fromHeaders(headers(
+          MessageProducer -> VertxProducer,
+          LocalLogId -> "logA",
+          LocalSequenceNr -> 1L,
+          EmitterId -> "emitter1")
+        )
+
+        metadata.map(_.localLogId) mustBe Some("logA")
+        metadata.map(_.localSequenceNr) mustBe Some(1L)
+        metadata.map(_.emitterId) mustBe Some("emitter1")
+      }
+    }
+    "supplied with invalid headers" must {
+      "be empty if the source is not specified" in {
+        val metadata = EventMetadata.fromHeaders(headers(
+          LocalLogId -> "logA",
+          LocalSequenceNr -> 1L,
+          EmitterId -> "emitter1")
+        )
+
+        metadata mustBe None
+      }
+      "be empty if the headers are empty" in {
+        val metadata = EventMetadata.fromHeaders(headers())
+
+        metadata mustBe None
+      }
+      "fail to instantiate if the values have the wrong type" in {
+        a [NumberFormatException] must be thrownBy EventMetadata.fromHeaders(headers(
+          MessageProducer -> VertxProducer,
+          LocalLogId -> "logA",
+          LocalSequenceNr -> "i_am_not_a_long_value",
+          EmitterId -> "emitter1")
+        )
+      }
+      "fail to instantiate if the a value is missing" in {
+        an [IllegalArgumentException] must be thrownBy EventMetadata.fromHeaders(headers(
+          MessageProducer -> VertxProducer,
+          LocalSequenceNr -> 1L,
+          EmitterId -> "emitter1")
+        )
+      }
+    }
+  }
+}

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcherSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcherSpec.scala
@@ -22,7 +22,6 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import com.rbmhtechnology.eventuate.EventsourcingProtocol._
 import com.rbmhtechnology.eventuate.adapter.vertx.LogEventDispatcher.{EndpointRoute, EventProducerRef}
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult
 import com.rbmhtechnology.eventuate.utilities._
 import com.rbmhtechnology.eventuate.{EventsourcedView, SingleLocationSpecLeveldb}
 import io.vertx.core.eventbus.{Message, ReplyException}

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxBatchConfirmationSenderSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxBatchConfirmationSenderSpec.scala
@@ -19,7 +19,7 @@ package com.rbmhtechnology.eventuate.adapter.vertx
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestKit
 import com.rbmhtechnology.eventuate.SingleLocationSpecLeveldb
-import com.rbmhtechnology.eventuate.adapter.vertx.api.{Confirmation, EndpointRouter}
+import com.rbmhtechnology.eventuate.adapter.vertx.api.EndpointRouter
 import org.scalatest.{MustMatchers, WordSpecLike}
 
 import scala.concurrent.duration._

--- a/eventuate-adapter-vertx/src/main/java/com/rbmhtechnology/eventuate/adapter/vertx/ProcessingResult.java
+++ b/eventuate-adapter-vertx/src/main/java/com/rbmhtechnology/eventuate/adapter/vertx/ProcessingResult.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.eventuate.adapter.vertx.japi;
+package com.rbmhtechnology.eventuate.adapter.vertx;
 
 public enum ProcessingResult {
   FILTERED,

--- a/eventuate-adapter-vertx/src/main/java/com/rbmhtechnology/eventuate/adapter/vertx/japi/EventMetadata.java
+++ b/eventuate-adapter-vertx/src/main/java/com/rbmhtechnology/eventuate/adapter/vertx/japi/EventMetadata.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.adapter.vertx.japi;
+
+import io.vertx.core.MultiMap;
+import scala.Option;
+
+import java.util.Optional;
+
+/**
+ * Contains metadata of an event originating from an event log.
+ */
+public class EventMetadata {
+
+  public static class Headers {
+    public static final String LOCAL_SEQUENCE_NR =
+      com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata.Headers$.MODULE$.LocalSequenceNr();
+    public static final String LOCAL_LOG_ID =
+      com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata.Headers$.MODULE$.LocalLogId();
+    public static final String EMITTER_ID =
+      com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata.Headers$.MODULE$.EmitterId();
+  }
+
+  private final com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata underlying;
+
+  private EventMetadata(com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata underlying) {
+    this.underlying = underlying;
+  }
+
+  /**
+   * Creates an instance of [[EventMetadata]] containing event metadata extracted from the headers of an event bus message
+   * if this message originated from a Vert.x producer.
+   *
+   * @param headers Headers of the event bus message.
+   * @return An [[Optional]] containing the metadata if this message was sent by a Vert.x producer otherwise an empty [[Optional]].
+   */
+  public static Optional<EventMetadata> fromHeaders(final MultiMap headers) {
+    return toOptional(com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata.fromHeaders(headers)).map(EventMetadata::new);
+  }
+
+  /**
+   * Creates an instance of [[EventMetadata]] containing event metadata extracted from the headers of an event bus message
+   * if this message originated from a Vert.x producer.
+   *
+   * @param headers Headers of the event bus message.
+   * @return An [[Optional]] containing the metadata if this message was sent by a Vert.x producer otherwise an empty [[Optional]].
+   */
+  public static Optional<EventMetadata> fromHeaders(final io.vertx.rxjava.core.MultiMap headers) {
+    return toOptional(com.rbmhtechnology.eventuate.adapter.vertx.api.EventMetadata.fromHeaders(headers)).map(EventMetadata::new);
+  }
+
+  private static <A> Optional<A> toOptional(final Option<A> opt) {
+    return opt.isDefined() ? Optional.of(opt.get()) : Optional.empty();
+  }
+
+  /**
+   * Id of the local event log.
+   */
+  public String localLogId() {
+    return underlying.localLogId();
+  }
+
+  /**
+   * Sequence number in the local event log.
+   */
+  public Long localSequenceNr() {
+    return underlying.localSequenceNr();
+  }
+
+  /**
+   * Id of the emitter ([[EventsourcedActor]] or [[EventsourcedProcessor]]).
+   */
+  public String emitterId() {
+    return underlying.emitterId();
+  }
+}

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/Confirmation.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/Confirmation.scala
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.eventuate.adapter.vertx.utilities
+package com.rbmhtechnology.eventuate.adapter.vertx
 
-import com.rbmhtechnology.eventuate.adapter.vertx.Confirmation
-import io.vertx.core.MultiMap
-import io.vertx.core.eventbus.Message
-
-case class VertxEventBusMessage[T](body: T, message: Message[T]) {
-  def confirm(): Unit = {
-    message.reply(Confirmation)
-  }
-
-  def headers: MultiMap =
-    message.headers()
+case object Confirmation {
+  def create = this
 }

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcher.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcher.scala
@@ -19,7 +19,6 @@ package com.rbmhtechnology.eventuate.adapter.vertx
 import akka.actor.{ Actor, ActorRef, Props }
 import com.rbmhtechnology.eventuate.adapter.vertx.LogEventDispatcher.EndpointRoute
 import com.rbmhtechnology.eventuate.adapter.vertx.LogProducer.PersistMessage
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult.FILTERED
 import io.vertx.core.Vertx
 import io.vertx.core.eventbus.{ Message, MessageConsumer }
 
@@ -48,7 +47,7 @@ class LogEventDispatcher(routes: Seq[EndpointRoute], vertx: Vertx) extends Actor
       if (filter.applyOrElse(msg.body(), (_: Any) => false)) {
         producer ! PersistMessage(msg)
       } else {
-        msg.reply(FILTERED)
+        msg.reply(ProcessingResult.FILTERED)
       }
     }
     vertx.eventBus().consumer[Any](endpoint, handler.asVertxHandler)

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogProducer.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogProducer.scala
@@ -18,7 +18,6 @@ package com.rbmhtechnology.eventuate.adapter.vertx
 
 import akka.actor.{ ActorRef, Props }
 import com.rbmhtechnology.eventuate.EventsourcedActor
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult.PERSISTED
 import io.vertx.core.eventbus.Message
 
 import scala.util.{ Failure, Success }
@@ -42,7 +41,7 @@ private[vertx] class LogProducer(val id: String, val eventLog: ActorRef) extends
   override def onCommand: Receive = {
     case PersistMessage(msg) =>
       persist(msg.body()) {
-        case Success(res) => msg.reply(PERSISTED)
+        case Success(res) => msg.reply(ProcessingResult.PERSISTED)
         case Failure(err) => msg.fail(0, err.getMessage)
       }
   }

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxEventDispatcher.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxEventDispatcher.scala
@@ -16,13 +16,13 @@
 
 package com.rbmhtechnology.eventuate.adapter.vertx
 
-import com.rbmhtechnology.eventuate.EventsourcedWriter
+import com.rbmhtechnology.eventuate.{ DurableEvent, EventsourcedWriter }
 import com.rbmhtechnology.eventuate.adapter.vertx.api.EndpointRouter
 
 import scala.collection.immutable.Seq
 import scala.concurrent.{ ExecutionContext, Future }
 
-case class EventEnvelope(address: String, evt: Any)
+case class EventEnvelope(address: String, evt: DurableEvent)
 
 trait VertxEventDispatcher[R, W] extends EventsourcedWriter[R, W] with ProgressStore[R, W] {
   import context.dispatcher
@@ -40,7 +40,7 @@ trait VertxEventDispatcher[R, W] extends EventsourcedWriter[R, W] with ProgressS
   override def onEvent: Receive = {
     case ev =>
       events = endpointRouter.endpoint(ev) match {
-        case Some(endpoint) => events :+ EventEnvelope(endpoint, ev)
+        case Some(endpoint) => events :+ EventEnvelope(endpoint, lastHandledEvent)
         case None           => events
       }
   }

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxSingleConfirmationSender.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxSingleConfirmationSender.scala
@@ -75,7 +75,7 @@ private[vertx] class VertxSingleConfirmationSender(val id: String, val eventLog:
       endpointRouter.endpoint(ev) match {
         case Some(endpoint) =>
           val deliveryId = lastSequenceNr.toString
-          deliver(deliveryId, DeliverEvent(EventEnvelope(endpoint, ev), deliveryId), self.path)
+          deliver(deliveryId, DeliverEvent(EventEnvelope(endpoint, lastHandledEvent), deliveryId), self.path)
         case None =>
       }
   }

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/EventMetadata.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/EventMetadata.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.adapter.vertx.api
+
+import com.rbmhtechnology.eventuate.{ DurableEvent, EventsourcedActor, EventsourcedProcessor }
+import io.vertx.core.MultiMap
+import io.vertx.rxjava.core.{ MultiMap => RxMultiMap }
+
+object EventMetadata {
+  import com.rbmhtechnology.eventuate.adapter.vertx.VertxExtensions._
+
+  private[vertx] val MessageProducer = "producer"
+  private[vertx] val VertxProducer = "vertx-producer"
+
+  object Headers {
+    val LocalSequenceNr = "localSequenceNr"
+    val LocalLogId = "localLogId"
+    val EmitterId = "emitterId"
+  }
+
+  /**
+   * Creates an instance of [[EventMetadata]] containing event metadata extracted from the headers of an event bus message
+   * if this message originated from a Vert.x producer.
+   *
+   * @param headers Headers of the event bus message.
+   * @return An [[Option]] containing the metadata if this message was sent by a Vert.x producer otherwise [[None]].
+   */
+  def fromHeaders(headers: MultiMap): Option[EventMetadata] =
+    headers.getAsOption(MessageProducer).filter(_ == VertxProducer)
+      .map { s =>
+        new EventMetadata(
+          headers.getOrElseThrow(Headers.LocalLogId),
+          headers.getOrElseThrow(Headers.LocalSequenceNr).toLong,
+          headers.getOrElseThrow(Headers.EmitterId))
+      }
+
+  /**
+   * Creates an instance of [[EventMetadata]] containing event metadata extracted from the headers of an event bus message
+   * if this message originated from a Vert.x producer.
+   *
+   * @param headers Headers of the event bus message.
+   * @return An [[Option]] containing the metadata if this message was sent by a Vert.x producer otherwise [[None]].
+   */
+  def fromHeaders(headers: RxMultiMap): Option[EventMetadata] =
+    fromHeaders(headers.getDelegate.asInstanceOf[MultiMap])
+
+  private[vertx] def apply(event: DurableEvent): EventMetadata =
+    new EventMetadata(event.localLogId, event.localSequenceNr, event.emitterId)
+}
+
+/**
+ * Contains metadata of an event originating from an event log.
+ *
+ * @param localLogId      Id of the local event log.
+ * @param localSequenceNr Sequence number in the local event log.
+ * @param emitterId       Id of the emitter ([[EventsourcedActor]] or [[EventsourcedProcessor]]).
+ */
+class EventMetadata(val localLogId: String, val localSequenceNr: Long, val emitterId: String) {
+  import EventMetadata._
+
+  private[vertx] def toHeaders: MultiMap = {
+    val map = MultiMap.caseInsensitiveMultiMap()
+    map.set(MessageProducer, VertxProducer)
+    map.set(Headers.LocalLogId, localLogId)
+    map.set(Headers.LocalSequenceNr, localSequenceNr.toString)
+    map.set(Headers.EmitterId, emitterId)
+    map
+  }
+}

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/EventProducerConfig.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/EventProducerConfig.scala
@@ -152,7 +152,3 @@ class LogProducerConfigFactory(endpoints: Set[String]) {
       LogProducerConfig(id, log, endpoints, filter)
   }
 }
-
-case object Confirmation {
-  val create = this
-}

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/VertxAdapterConfig.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/api/VertxAdapterConfig.scala
@@ -16,10 +16,10 @@
 
 package com.rbmhtechnology.eventuate.adapter.vertx.api
 
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult
-import com.rbmhtechnology.eventuate.adapter.vertx.VertxAdapter
+import com.rbmhtechnology.eventuate.adapter.vertx.{ Confirmation, ProcessingResult, VertxAdapter }
 
 import scala.collection.immutable.Seq
+import scala.language.existentials
 
 object VertxAdapterConfig {
 

--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/package.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/package.scala
@@ -91,4 +91,19 @@ package object vertx {
       }
     }
   }
+
+  object VertxExtensions {
+
+    implicit class RichMultiMap(map: MultiMap) {
+      def getAsOption(name: String): Option[String] =
+        Option(map.get(name))
+
+      def getOrElseThrow(name: String): String =
+        if (map.contains(name)) {
+          map.get(name)
+        } else {
+          throw new IllegalArgumentException(s"No entry for key '$name' found.")
+        }
+    }
+  }
 }

--- a/eventuate-example-vertx/src/main/java/com/rbmhtechnology/docs/vertx/japi/Documentation.java
+++ b/eventuate-example-vertx/src/main/java/com/rbmhtechnology/docs/vertx/japi/Documentation.java
@@ -22,17 +22,19 @@ import akka.actor.ActorSystem;
 import com.rbmhtechnology.eventuate.ApplicationVersion;
 import com.rbmhtechnology.eventuate.EndpointFilters$;
 import com.rbmhtechnology.eventuate.ReplicationEndpoint;
+import com.rbmhtechnology.eventuate.adapter.vertx.Confirmation;
+import com.rbmhtechnology.eventuate.adapter.vertx.ProcessingResult;
 import com.rbmhtechnology.eventuate.adapter.vertx.VertxAdapter;
-import com.rbmhtechnology.eventuate.adapter.vertx.api.Confirmation;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.ConfirmationType;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.EventProducer;
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.StorageProvider;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.VertxAdapterConfig;
 import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog;
 import io.vertx.core.Vertx;
 //#
 
+import com.rbmhtechnology.eventuate.adapter.vertx.japi.EventMetadata;
+import io.vertx.core.MultiMap;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
@@ -177,6 +179,26 @@ public class Documentation {
     //#message-codec
     VertxAdapterConfig.create()
       .registerDefaultCodecFor(Event.class, Event2.class);
+    //#
+
+    //#event-metadata-from-headers
+    vertx.eventBus().<Event>consumer("address-1").handler(message -> {
+      MultiMap headers = message.headers();
+
+      String localLogId = headers.get(EventMetadata.Headers.LOCAL_LOG_ID);
+      Long localSeqNr = Long.valueOf(headers.get(EventMetadata.Headers.LOCAL_SEQUENCE_NR));
+      String emitterId = headers.get(EventMetadata.Headers.EMITTER_ID);
+    });
+    //#
+
+    //#event-metadata-from-helper
+    vertx.eventBus().<Event>consumer("address-1").handler(message -> {
+      EventMetadata metadata = EventMetadata.fromHeaders(message.headers()).get();
+
+      String localLogId = metadata.localLogId();
+      Long localSeqNr = metadata.localSequenceNr();
+      String emitterId = metadata.emitterId();
+    });
     //#
   }
 

--- a/eventuate-example-vertx/src/main/java/com/rbmhtechnology/example/vertx/japi/VertxAdapterExample.java
+++ b/eventuate-example-vertx/src/main/java/com/rbmhtechnology/example/vertx/japi/VertxAdapterExample.java
@@ -25,9 +25,9 @@ import com.rbmhtechnology.eventuate.AbstractEventsourcedView;
 import com.rbmhtechnology.eventuate.ApplicationVersion;
 import com.rbmhtechnology.eventuate.EndpointFilters$;
 import com.rbmhtechnology.eventuate.ReplicationEndpoint;
+import com.rbmhtechnology.eventuate.adapter.vertx.ProcessingResult;
 import com.rbmhtechnology.eventuate.adapter.vertx.VertxAdapter;
-import com.rbmhtechnology.eventuate.adapter.vertx.api.Confirmation;
-import com.rbmhtechnology.eventuate.adapter.vertx.api.Confirmation$;
+import com.rbmhtechnology.eventuate.adapter.vertx.Confirmation;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.ConfirmationType;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.EventProducer;
 import com.rbmhtechnology.eventuate.adapter.vertx.japi.VertxAdapterConfig;
@@ -144,7 +144,7 @@ public class VertxAdapterExample {
             } else {
               out.println(String.format("[v_processor] processed [%s]", ev));
 
-              vertx.eventBus().sendObservable(Endpoints.WRITER, ev.copy("*processed*" + ev.id()))
+              vertx.eventBus().<ProcessingResult>sendObservable(Endpoints.WRITER, ev.copy("*processed*" + ev.id()))
                 .subscribe(
                   res -> {
                     confirmedEvents = confirmedEvents.add(ev);

--- a/eventuate-example-vertx/src/main/scala/com/rbmhtechnology/docs/vertx/Documentation.scala
+++ b/eventuate-example-vertx/src/main/scala/com/rbmhtechnology/docs/vertx/Documentation.scala
@@ -16,8 +16,8 @@
 
 package com.rbmhtechnology.docs.vertx
 
-import com.rbmhtechnology.eventuate.adapter.vertx.api.{ Batch, Confirmation, StorageProvider }
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult
+import com.rbmhtechnology.eventuate.adapter.vertx.{ Confirmation, ProcessingResult }
+import com.rbmhtechnology.eventuate.adapter.vertx.api.{ Batch, EventMetadata, StorageProvider }
 import io.vertx.core.AsyncResult
 
 import scala.concurrent.duration._
@@ -164,5 +164,29 @@ object Documentation {
   //#message-codec
   VertxAdapterConfig()
     .registerDefaultCodecFor(classOf[Event], classOf[Event2])
+  //#
+
+  //#event-metadata-from-headers
+  vertx.eventBus().consumer[Event]("address-1").handler(new Handler[Message[Event]] {
+    override def handle(message: Message[Event]): Unit = {
+      val headers = message.headers
+
+      val localLogId = headers.get(EventMetadata.Headers.LocalLogId)
+      val localSeqNr = headers.get(EventMetadata.Headers.LocalSequenceNr).toLong
+      val emitterId = headers.get(EventMetadata.Headers.EmitterId)
+    }
+  })
+  //#
+
+  //#event-metadata-from-helper
+  vertx.eventBus().consumer[Event]("address-1").handler(new Handler[Message[Event]] {
+    override def handle(message: Message[Event]): Unit = {
+      val metadata = EventMetadata.fromHeaders(message.headers).get
+
+      val localLogId = metadata.localLogId
+      val localSeqNr = metadata.localSequenceNr
+      val emitterId = metadata.emitterId
+    }
+  })
   //#
 }

--- a/eventuate-example-vertx/src/main/scala/com/rbmhtechnology/example/vertx/VertxAdapterExample.scala
+++ b/eventuate-example-vertx/src/main/scala/com/rbmhtechnology/example/vertx/VertxAdapterExample.scala
@@ -25,7 +25,6 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.rbmhtechnology.eventuate.adapter.vertx._
 import com.rbmhtechnology.eventuate.adapter.vertx.api._
-import com.rbmhtechnology.eventuate.adapter.vertx.japi.ProcessingResult
 import com.rbmhtechnology.eventuate.log.EventLogWriter
 import com.rbmhtechnology.eventuate.log.leveldb.LeveldbEventLog
 import com.rbmhtechnology.eventuate.{ EventsourcedView, ReplicationConnection, ReplicationEndpoint }

--- a/src/sphinx/reference/adapters.rst
+++ b/src/sphinx/reference/adapters.rst
@@ -251,6 +251,30 @@ A message codec for the type is created which uses the ``Serializer`` assigned t
 .. note::
    The generic ``MessageCodec`` can also be used for events not stored in an event log if a ``Serializer`` for the event type is configured at the ``ActorSystem``. If no ``Serializer`` for a type is configured the generated ``MessageCodec`` will fail to process instances of the type.
 
+Event Metadata
+~~~~~~~~~~~~~~
+
+Applications can access the metadata of an event by querying the `headers`_ of an event bus message. The following metadata is available for each event:
+
+- the *local log id* of the event,
+- the *local sequence number* of the event and
+- the *id of the emitter* that persisted the event.
+
+.. tabbed-code::
+   .. includecode:: ../../../eventuate-example-vertx/src/main/scala/com/rbmhtechnology/docs/vertx/Documentation.scala
+      :snippet: event-metadata-from-headers
+   .. includecode:: ../../../eventuate-example-vertx/src/main/java/com/rbmhtechnology/docs/vertx/japi/Documentation.java
+      :snippet: event-metadata-from-headers
+
+The Vert.x adapter also offers the ``EventMetadata`` helper, which is instantiated from the message headers and provides the metadata of an event.
+An ``EventMetadata`` instance is only created if the message originated from a Vert.x producer.
+
+.. tabbed-code::
+   .. includecode:: ../../../eventuate-example-vertx/src/main/scala/com/rbmhtechnology/docs/vertx/Documentation.scala
+      :snippet: event-metadata-from-helper
+   .. includecode:: ../../../eventuate-example-vertx/src/main/java/com/rbmhtechnology/docs/vertx/japi/Documentation.java
+      :snippet: event-metadata-from-helper
+
 .. hint::
    A detailed example can be found in `VertxAdapterExample.scala`_ or `VertxAdapterExample.java`_.
 
@@ -270,6 +294,7 @@ A message codec for the type is created which uses the ``Serializer`` assigned t
 .. _event bus: http://vertx.io/docs/vertx-core/java/#event_bus
 .. _message codec: http://vertx.io/docs/apidocs/io/vertx/core/eventbus/MessageCodec.html
 .. _message: http://vertx.io/docs/apidocs/io/vertx/core/eventbus/Message.html
+.. _headers: http://vertx.io/docs/apidocs/io/vertx/core/eventbus/Message.html#headers--
 .. _VertxAdapterExample.scala: https://github.com/RBMHTechnology/eventuate/blob/master/eventuate-example-vertx/src/main/scala/com/rbmhtechnology/example/vertx/VertxAdapterExample.scala
 .. _VertxAdapterExample.java: https://github.com/RBMHTechnology/eventuate/blob/master/eventuate-example-vertx/src/main/java/com/rbmhtechnology/example/vertx/japi/VertxAdapterExample.java
 


### PR DESCRIPTION
- add event metadata to all Vert.x event bus messages delivered by the Vert.x adapter
- offer EventMetadata helper to access the metadata from the event bus message headers

- closes #321