### PR TITLE
Support binary payload serializer for DurableEvents

### DIFF
--- a/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/AkkaSerializationMessageCodec.scala
+++ b/eventuate-adapter-vertx/src/main/scala/com/rbmhtechnology/eventuate/adapter/vertx/AkkaSerializationMessageCodec.scala
@@ -18,7 +18,7 @@ package com.rbmhtechnology.eventuate.adapter.vertx
 
 import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import com.rbmhtechnology.eventuate.serializer.CommonFormats.PayloadFormat
-import com.rbmhtechnology.eventuate.serializer.CommonSerializer
+import com.rbmhtechnology.eventuate.serializer.DelegatingPayloadSerializer
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.eventbus.MessageCodec
 
@@ -67,7 +67,7 @@ object PayloadSerializationExtension extends ExtensionId[PayloadSerializationExt
 
 class PayloadSerializationExtension(system: ExtendedActorSystem) extends Extension {
 
-  val serializer = new CommonSerializer(system)
+  val serializer = new DelegatingPayloadSerializer(system)
 
   def toBinary(o: AnyRef): Array[Byte] =
     serializer.payloadFormatBuilder(o).build().toByteArray

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/ReplicationIntegrationSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/ReplicationIntegrationSpec.scala
@@ -16,21 +16,59 @@
 
 package com.rbmhtechnology.eventuate
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
 import akka.actor._
+import akka.serialization.Serializer
 import akka.testkit.TestProbe
 import com.rbmhtechnology.eventuate.EndpointFilters.sourceFilters
 import com.rbmhtechnology.eventuate.EndpointFilters.targetOverwritesSourceFilters
 import com.rbmhtechnology.eventuate.ReplicationFilter.NoFilter
 import com.rbmhtechnology.eventuate.ReplicationProtocol.ReplicationEndpointInfo.logId
 import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.rbmhtechnology.eventuate.serializer.DurableEventSerializerWithBinaryPayload
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util._
+import scala.util.control.Exception.ultimately
 
 object ReplicationIntegrationSpec {
+  class JavaSerializerWithManifest(system: ExtendedActorSystem) extends Serializer {
+    override def includeManifest: Boolean = true
+
+    override val identifier: Int = 647345238
+
+    def toBinary(o: AnyRef): Array[Byte] = {
+      val bos = new ByteArrayOutputStream
+      val out = new ObjectOutputStream(bos)
+      ultimately(out.close())(out.writeObject(o))
+      bos.toByteArray
+    }
+
+    def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = {
+      val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+      ultimately(in.close())(in.readObject())
+    }
+  }
+
+  def javaSerializerWithManifestFor(types: Class[_]*): Config = {
+    ConfigFactory.parseString(
+      s"""
+        |akka.actor.serializers.java-serializer-with-manifest = "com.rbmhtechnology.eventuate.ReplicationIntegrationSpec$$JavaSerializerWithManifest"
+        |akka.actor.serialization-bindings {
+        |  ${types.map(t => s"""  "${t.getName}" = java-serializer-with-manifest""").mkString("\n")}
+        |}
+      """.stripMargin)
+  }
+
   class PayloadEqualityFilter(payload: String) extends ReplicationFilter {
     override def apply(event: DurableEvent): Boolean = {
       event.payload == payload
@@ -47,14 +85,14 @@ object ReplicationIntegrationSpec {
     override val stateSync = false
 
     def onCommand = {
-      case s: String => persist(s) {
+      case s => persist(s) {
         case Success(e) =>
         case Failure(e) => throw e
       }
     }
 
     def onEvent = {
-      case s: String => probe ! s
+      case s => probe ! s
     }
   }
 
@@ -181,6 +219,32 @@ trait ReplicationIntegrationSpec extends WordSpec with Matchers with MultiLocati
 
       val eventsA = locationA.probe.expectMsgAllOf("a1", "a2", "a3", "b3")
       val eventsB = locationB.probe.expectMsgAllOf("b1", "b2", "b3", "a3")
+    }
+    "replicate events according to BinaryPayload based local filters" in {
+      val locationA = location("A", 
+        customConfig = javaSerializerWithManifestFor(classOf[String], classOf[Integer]))
+      val locationB = location("B",
+        customConfig = ConfigFactory.parseString(
+          s"akka.actor.serializers.eventuate-durable-event = ${classOf[DurableEventSerializerWithBinaryPayload].getName}"))
+      val locationC = location("C", 
+        customConfig = javaSerializerWithManifestFor(classOf[String], classOf[Integer]))
+
+      val endpointA = 
+        locationA.endpoint(Set("L1"), Set(replicationConnection(locationB.port)))
+      locationB.endpoint(Set("L1"),
+        Set(replicationConnection(locationA.port), replicationConnection(locationC.port)),
+        sourceFilters(Map("L1" -> BinaryPayloadManifestFilter(".*String".r))))
+      val endpointC = 
+        locationC.endpoint(Set("L1"), Set(replicationConnection(locationB.port)))
+
+      val actorA = locationA.system.actorOf(Props(new ReplicatedActor("pa", endpointA.logs("L1"), locationA.probe.ref)))
+      locationC.system.actorOf(Props(new ReplicatedActor("pc", endpointC.logs("L1"), locationC.probe.ref)))
+
+      actorA ! "a1"
+      actorA ! 2
+      actorA ! "a2"
+
+      locationC.probe.expectMsgAllOf("a1", "a2")
     }
     "immediately attempt next batch if last replicated batch was not empty" in {
       val locationA = location("A")

--- a/eventuate-core/src/main/resources/reference.conf
+++ b/eventuate-core/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 akka {
   actor {
     serializers {
-      eventuate-durable-event = "com.rbmhtechnology.eventuate.serializer.DurableEventSerializer"
+      eventuate-durable-event = "com.rbmhtechnology.eventuate.serializer.DelegatingDurableEventSerializer"
       eventuate-replication-filter = "com.rbmhtechnology.eventuate.serializer.ReplicationFilterSerializer"
       eventuate-replication-protocol = "com.rbmhtechnology.eventuate.serializer.ReplicationProtocolSerializer"
       eventuate-snapshot = "com.rbmhtechnology.eventuate.serializer.SnapshotSerializer"

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/BinaryPayload.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/BinaryPayload.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+import com.google.protobuf.ByteString
+
+/**
+ * Represents a serialized payload.
+ * @param bytes Serialized payload
+ * @param serializerId [[akka.serialization.Serializer.identifier]] of the [[akka.serialization.Serializer]]
+ *                     that creates the serialized payload
+ * @param manifest The optional manifest provided by the [[akka.serialization.Serializer]]
+ * @param isStringManifest `true` if `manifest` is a string manifest (from a [[akka.serialization.SerializerWithStringManifest]])
+ */
+private[eventuate] case class BinaryPayload(bytes: ByteString, serializerId: Int, manifest: Option[String], isStringManifest: Boolean)

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/BinaryPayloadManifestFilter.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/BinaryPayloadManifestFilter.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+import scala.util.matching.Regex
+
+/**
+ * A [[ReplicationFilter]] that can be used in combination with
+ * [[com.rbmhtechnology.eventuate.serializer.DurableEventSerializerWithBinaryPayload]].
+ *
+ * It evaluates to `true` if the payload's manifest matches `regex`.
+ */
+case class BinaryPayloadManifestFilter(regex: Regex) extends ReplicationFilter {
+
+  override def apply(event: DurableEvent): Boolean = event.payload match {
+    case BinaryPayload(_, _, Some(regex(_*)), _) => true
+    case _                                       => false
+  }
+}
+
+object BinaryPayloadManifestFilter {
+
+  /**
+   * Creates a [[BinaryPayloadManifestFilter]] for the regex given in `pattern`.
+   */
+  def create(pattern: String): BinaryPayloadManifestFilter =
+    BinaryPayloadManifestFilter(pattern.r)
+}

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/PayloadSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/PayloadSerializer.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate.serializer
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.SerializationExtension
+import akka.serialization.SerializerWithStringManifest
+import com.google.protobuf.ByteString
+import com.rbmhtechnology.eventuate.BinaryPayload
+import com.rbmhtechnology.eventuate.serializer.CommonFormats.PayloadFormat
+
+/**
+ * Interface of a serializer converting between payloads and `PayloadFormat`.
+ */
+trait PayloadSerializer {
+  def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder
+  def payload(payloadFormat: PayloadFormat): AnyRef
+}
+
+/**
+ * A [[PayloadSerializer]] delegating to a serializer that is configured with Akka's
+ * [[http://doc.akka.io/docs/akka/2.3.9/scala/serialization.html serialization extension]] mechanism.
+ */
+class DelegatingPayloadSerializer(system: ExtendedActorSystem) extends PayloadSerializer {
+
+  override def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder = {
+    val serializer = SerializationExtension(system).findSerializerFor(payload)
+    val builder = PayloadFormat.newBuilder()
+
+    if (serializer.includeManifest) {
+      val stringManifest = serializer match {
+        case serializerWithStringManifest: SerializerWithStringManifest =>
+          builder.setIsStringManifest(true)
+          serializerWithStringManifest.manifest(payload)
+        case _ =>
+          payload.getClass.getName
+      }
+      builder.setPayloadManifest(stringManifest)
+    }
+
+    builder.setPayload(ByteString.copyFrom(serializer.toBinary(payload)))
+    builder.setSerializerId(serializer.identifier)
+    builder
+  }
+
+  override def payload(payloadFormat: PayloadFormat): AnyRef = {
+    val deserialized = if (payloadFormat.getIsStringManifest) {
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        payloadFormat.getSerializerId,
+        payloadFormat.getPayloadManifest)
+    } else if (payloadFormat.hasPayloadManifest) {
+      val manifestClass = system.dynamicAccess.getClassFor[AnyRef](payloadFormat.getPayloadManifest).get
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        manifestClass)
+    } else {
+      SerializationExtension(system).deserialize(
+        payloadFormat.getPayload.toByteArray,
+        payloadFormat.getSerializerId,
+        None)
+    }
+    deserialized.get
+  }
+}
+
+/**
+ * A [[PayloadSerializer]] converting between `BinaryPayloads` and `PayloadFormats`.
+ */
+class BinaryPayloadSerializer(system: ExtendedActorSystem) extends PayloadSerializer {
+
+  override def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder = {
+    val binaryPayload = payload.asInstanceOf[BinaryPayload]
+    val builder = PayloadFormat.newBuilder()
+      .setPayload(binaryPayload.bytes)
+      .setSerializerId(binaryPayload.serializerId)
+      .setIsStringManifest(binaryPayload.isStringManifest)
+    binaryPayload.manifest.foreach(builder.setPayloadManifest)
+    builder
+  }
+
+  override def payload(payloadFormat: PayloadFormat): AnyRef = {
+    BinaryPayload(
+      payloadFormat.getPayload,
+      payloadFormat.getSerializerId,
+      if (payloadFormat.hasPayloadManifest) Some(payloadFormat.getPayloadManifest) else None,
+      payloadFormat.getIsStringManifest)
+  }
+}

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationFilterSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/ReplicationFilterSerializer.scala
@@ -32,7 +32,7 @@ import scala.language.existentials
 class ReplicationFilterSerializer(system: ExtendedActorSystem) extends Serializer {
   import ReplicationFilterTreeFormat.NodeType._
 
-  val commonSerializer = new CommonSerializer(system)
+  val payloadSerializer = new DelegatingPayloadSerializer(system)
 
   val AndFilterClass = classOf[AndFilter]
   val OrFilterClass = classOf[OrFilter]
@@ -77,7 +77,7 @@ class ReplicationFilterSerializer(system: ExtendedActorSystem) extends Serialize
         filters.foreach(filter => builder.addChildren(filterTreeFormatBuilder(filter)))
       case filter =>
         builder.setNodeType(LEAF)
-        builder.setFilter(commonSerializer.payloadFormatBuilder(filter))
+        builder.setFilter(payloadSerializer.payloadFormatBuilder(filter))
     }
     builder
   }
@@ -90,7 +90,7 @@ class ReplicationFilterSerializer(system: ExtendedActorSystem) extends Serialize
     filterTreeFormat.getNodeType match {
       case AND  => AndFilter(filterTreeFormat.getChildrenList.asScala.map(filterTree).toList)
       case OR   => OrFilter(filterTreeFormat.getChildrenList.asScala.map(filterTree).toList)
-      case LEAF => commonSerializer.payload(filterTreeFormat.getFilter).asInstanceOf[ReplicationFilter]
+      case LEAF => payloadSerializer.payload(filterTreeFormat.getFilter).asInstanceOf[ReplicationFilter]
     }
   }
 }

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializer.scala
@@ -18,7 +18,6 @@ package com.rbmhtechnology.eventuate.serializer
 
 import akka.actor._
 import akka.serialization.Serializer
-
 import com.rbmhtechnology.eventuate._
 import com.rbmhtechnology.eventuate.ConfirmedDelivery._
 import com.rbmhtechnology.eventuate.PersistOnEvent._
@@ -29,9 +28,10 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.VectorBuilder
 
 class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
-  val eventSerializer = new DurableEventSerializer(system)
+  val eventSerializer = new DelegatingDurableEventSerializer(system)
 
   import eventSerializer.commonSerializer
+  import commonSerializer.payloadSerializer
 
   val SnapshotClass = classOf[Snapshot]
   val ConcurrentVersionsTreeClass = classOf[ConcurrentVersionsTree[_, _]]
@@ -71,7 +71,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
 
   private def snapshotFormatBuilder(snapshot: Snapshot): SnapshotFormat.Builder = {
     val builder = SnapshotFormat.newBuilder
-    builder.setPayload(commonSerializer.payloadFormatBuilder(snapshot.payload.asInstanceOf[AnyRef]))
+    builder.setPayload(payloadSerializer.payloadFormatBuilder(snapshot.payload.asInstanceOf[AnyRef]))
     builder.setEmitterId(snapshot.emitterId)
     builder.setLastEvent(eventSerializer.durableEventFormatBuilder(snapshot.lastEvent))
     builder.setCurrentTime(commonSerializer.vectorTimeFormatBuilder(snapshot.currentTime))
@@ -91,7 +91,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
   private def deliveryAttemptFormatBuilder(deliveryAttempt: DeliveryAttempt): DeliveryAttemptFormat.Builder = {
     val builder = DeliveryAttemptFormat.newBuilder
     builder.setDeliveryId(deliveryAttempt.deliveryId)
-    builder.setMessage(commonSerializer.payloadFormatBuilder(deliveryAttempt.message.asInstanceOf[AnyRef]))
+    builder.setMessage(payloadSerializer.payloadFormatBuilder(deliveryAttempt.message.asInstanceOf[AnyRef]))
     builder.setDestination(deliveryAttempt.destination.toSerializationFormat)
     builder
   }
@@ -110,7 +110,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
 
   private def persistOnEventInvocationFormatBuilder(persistOnEventInvocation: PersistOnEventInvocation): PersistOnEventInvocationFormat.Builder = {
     val builder = PersistOnEventInvocationFormat.newBuilder
-    builder.setEvent(commonSerializer.payloadFormatBuilder(persistOnEventInvocation.event.asInstanceOf[AnyRef]))
+    builder.setEvent(payloadSerializer.payloadFormatBuilder(persistOnEventInvocation.event.asInstanceOf[AnyRef]))
 
     persistOnEventInvocation.customDestinationAggregateIds.foreach { dest =>
       builder.addCustomDestinationAggregateIds(dest)
@@ -168,7 +168,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
       else durableEvent.localSequenceNr
 
     Snapshot(
-      commonSerializer.payload(snapshotFormat.getPayload),
+      payloadSerializer.payload(snapshotFormat.getPayload),
       snapshotFormat.getEmitterId,
       durableEvent,
       commonSerializer.vectorTime(snapshotFormat.getCurrentTime),
@@ -180,7 +180,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
   private def deliveryAttempt(deliveryAttemptFormat: DeliveryAttemptFormat): DeliveryAttempt = {
     DeliveryAttempt(
       deliveryAttemptFormat.getDeliveryId,
-      commonSerializer.payload(deliveryAttemptFormat.getMessage),
+      payloadSerializer.payload(deliveryAttemptFormat.getMessage),
       ActorPath.fromString(deliveryAttemptFormat.getDestination))
   }
 
@@ -203,7 +203,7 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
     }
 
     PersistOnEventInvocation(
-      commonSerializer.payload(persistOnEventInvocationFormat.getEvent),
+      payloadSerializer.payload(persistOnEventInvocationFormat.getEvent),
       customDestinationAggregateIds)
   }
 

--- a/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/BinaryPayloadManifestFilterSpec.scala
+++ b/eventuate-core/src/test/scala/com/rbmhtechnology/eventuate/BinaryPayloadManifestFilterSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+import com.google.protobuf.ByteString
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+object BinaryPayloadManifestFilterSpec {
+  def durableEventWithBinaryPayloadManifest(manifest: Option[String]): DurableEvent =
+    DurableEvent(BinaryPayload(ByteString.EMPTY, 0, manifest, isStringManifest = true), "emitterId")
+}
+
+class BinaryPayloadManifestFilterSpec extends WordSpec with Matchers {
+
+  import BinaryPayloadManifestFilterSpec._
+
+  "BinaryPayloadManifestFilter" must {
+    "pass BinaryPayloads with matching manifest" in {
+      BinaryPayloadManifestFilter("a.*".r).apply(durableEventWithBinaryPayloadManifest(Some("abc"))) should be(true)
+    }
+    "filter BinaryPayloads with partially matching manifest" in {
+      BinaryPayloadManifestFilter("b".r).apply(durableEventWithBinaryPayloadManifest(Some("abc"))) should be(false)
+    }
+    "filter BinaryPayloads with non-matching manifest" in {
+      BinaryPayloadManifestFilter("a.*".r).apply(durableEventWithBinaryPayloadManifest(Some("bc"))) should be(false)
+    }
+    "filter BinaryPayloads without manifest" in {
+      BinaryPayloadManifestFilter("a.*".r).apply(durableEventWithBinaryPayloadManifest(None)) should be(false)
+    }
+    "filter other payload" in {
+      BinaryPayloadManifestFilter("a.*".r).apply(DurableEvent("payload", "emitterId")) should be(false)
+    }
+  }
+}


### PR DESCRIPTION
Next to the default DurableEventSerializer there is an additional
DurableEventSerializerWithBinaryPayload that does not use akka's
serialization mechanism for de-/serializing payloads but
de-/serializes payloads from/into BinaryPayload instances. This can
be useful in scenarios where an Eventuate application is just used for
event forwarding (through replication) and only handles the
payload of events based on their metadata (like the manifest).