### PR TITLE
Minor CRDT API and implementation enhancements

### DIFF
--- a/eventuate-crdt/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTSerializerSpec.scala
+++ b/eventuate-crdt/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTSerializerSpec.scala
@@ -34,10 +34,10 @@ object CRDTSerializerSpec {
     ORCartEntry(key, 4)
 
   def mvRegister(payload: ExamplePayload) =
-    MVRegister[ExamplePayload].set(payload, VectorTime("s" -> 18L), 18, "e1")
+    MVRegister[ExamplePayload].assign(payload, VectorTime("s" -> 18L), 18, "e1")
 
   def lwwRegister(payload: ExamplePayload) =
-    LWWRegister[ExamplePayload].set(payload, VectorTime("s" -> 19L), 19, "e2")
+    LWWRegister[ExamplePayload].assign(payload, VectorTime("s" -> 19L), 19, "e2")
 
   def removeOp(payload: ExamplePayload): RemoveOp =
     RemoveOp(payload, Set(VectorTime("s" -> 19L), VectorTime("t" -> 20L)))
@@ -134,30 +134,30 @@ class CRDTSerializerSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     "support ValueUpdated serialization with default payload serialization" in {
       val serialization = SerializationExtension(systems(0))
 
-      val initial = ValueUpdated(SetOp(ExamplePayload("foo", "bar")))
+      val initial = ValueUpdated(AssignOp(ExamplePayload("foo", "bar")))
       val expected = initial
 
       serialization.deserialize(serialization.serialize(initial).get, classOf[ValueUpdated]).get should be(expected)
     }
     "support ValueUpdated serialization with custom payload serialization" in serializations.tail.foreach { serialization =>
-      val initial = ValueUpdated(SetOp(ExamplePayload("foo", "bar")))
-      val expected = ValueUpdated(SetOp(ExamplePayload("bar", "foo")))
+      val initial = ValueUpdated(AssignOp(ExamplePayload("foo", "bar")))
+      val expected = ValueUpdated(AssignOp(ExamplePayload("bar", "foo")))
 
       serialization.deserialize(serialization.serialize(initial).get, classOf[ValueUpdated]).get should be(expected)
     }
     "support SetOp serialization with default payload serialization" in {
       val serialization = SerializationExtension(systems(0))
 
-      val initial = SetOp(ExamplePayload("foo", "bar"))
+      val initial = AssignOp(ExamplePayload("foo", "bar"))
       val expected = initial
 
-      serialization.deserialize(serialization.serialize(initial).get, classOf[SetOp]).get should be(expected)
+      serialization.deserialize(serialization.serialize(initial).get, classOf[AssignOp]).get should be(expected)
     }
     "support SetOp serialization with custom payload serialization" in serializations.tail.foreach { serialization =>
-      val initial = SetOp(ExamplePayload("foo", "bar"))
-      val expected = SetOp(ExamplePayload("bar", "foo"))
+      val initial = AssignOp(ExamplePayload("foo", "bar"))
+      val expected = AssignOp(ExamplePayload("bar", "foo"))
 
-      serialization.deserialize(serialization.serialize(initial).get, classOf[SetOp]).get should be(expected)
+      serialization.deserialize(serialization.serialize(initial).get, classOf[AssignOp]).get should be(expected)
     }
     "support AddOp serialization with default payload serialization" in {
       val serialization = SerializationExtension(systems(0))

--- a/eventuate-crdt/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpecLeveldb.scala
+++ b/eventuate-crdt/src/it/scala/com/rbmhtechnology/eventuate/crdt/CRDTServiceSpecLeveldb.scala
@@ -38,8 +38,8 @@ class CRDTServiceSpecLeveldb extends TestKit(ActorSystem("test")) with WordSpecL
       val service2 = new MVRegisterService[Int]("b", log)
       val service3 = new LWWRegisterService[Int]("c", log)
       service1.update("a", 1).await should be(1)
-      service2.set("a", 1).await should be(Set(1))
-      service3.set("a", 1).await should be(Some(1))
+      service2.assign("a", 1).await should be(Set(1))
+      service3.assign("a", 1).await should be(Some(1))
     }
   }
 
@@ -69,7 +69,7 @@ class CRDTServiceSpecLeveldb extends TestKit(ActorSystem("test")) with WordSpecL
     }
     "return the written value of an MVRegister" in {
       val service = new MVRegisterService[Int]("a", log)
-      service.set("a", 1).await should be(Set(1))
+      service.assign("a", 1).await should be(Set(1))
       service.value("a").await should be(Set(1))
     }
   }
@@ -81,7 +81,7 @@ class CRDTServiceSpecLeveldb extends TestKit(ActorSystem("test")) with WordSpecL
     }
     "return the written value of an LWWRegister" in {
       val service = new LWWRegisterService[Int]("a", log)
-      service.set("a", 1).await should be(Some(1))
+      service.assign("a", 1).await should be(Some(1))
       service.value("a").await should be(Some(1))
     }
   }

--- a/eventuate-crdt/src/main/protobuf/CRDTFormats.proto
+++ b/eventuate-crdt/src/main/protobuf/CRDTFormats.proto
@@ -48,7 +48,7 @@ message UpdateOpFormat {
   optional PayloadFormat delta = 1;
 }
 
-message SetOpFormat {
+message AssignOpFormat {
   optional PayloadFormat value = 1;
 }
 

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/CRDTSerializer.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/CRDTSerializer.scala
@@ -36,7 +36,7 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
   private val ORCartEntryClass = classOf[ORCartEntry[_]]
   private val ValueUpdatedClass = classOf[ValueUpdated]
   private val UpdatedOpClass = classOf[UpdateOp]
-  private val SetOpClass = classOf[SetOp]
+  private val AssignOpClass = classOf[AssignOp]
   private val AddOpClass = classOf[AddOp]
   private val RemoveOpClass = classOf[RemoveOp]
 
@@ -58,8 +58,8 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
       valueUpdatedFormat(v).build().toByteArray
     case o: UpdateOp =>
       updateOpFormatBuilder(o).build().toByteArray
-    case o: SetOp =>
-      setOpFormatBuilder(o).build().toByteArray
+    case o: AssignOp =>
+      assignOpFormatBuilder(o).build().toByteArray
     case o: AddOp =>
       addOpFormatBuilder(o).build().toByteArray
     case o: RemoveOp =>
@@ -85,8 +85,8 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
         valueUpdated(ValueUpdatedFormat.parseFrom(bytes))
       case UpdatedOpClass =>
         updateOp(UpdateOpFormat.parseFrom(bytes))
-      case SetOpClass =>
-        setOp(SetOpFormat.parseFrom(bytes))
+      case AssignOpClass =>
+        assignOp(AssignOpFormat.parseFrom(bytes))
       case AddOpClass =>
         addOp(AddOpFormat.parseFrom(bytes))
       case RemoveOpClass =>
@@ -142,8 +142,8 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
   private def updateOpFormatBuilder(op: UpdateOp): UpdateOpFormat.Builder =
     UpdateOpFormat.newBuilder.setDelta(commonSerializer.payloadFormatBuilder(op.delta.asInstanceOf[AnyRef]))
 
-  private def setOpFormatBuilder(op: SetOp): SetOpFormat.Builder =
-    SetOpFormat.newBuilder.setValue(commonSerializer.payloadFormatBuilder(op.value.asInstanceOf[AnyRef]))
+  private def assignOpFormatBuilder(op: AssignOp): AssignOpFormat.Builder =
+    AssignOpFormat.newBuilder.setValue(commonSerializer.payloadFormatBuilder(op.value.asInstanceOf[AnyRef]))
 
   private def addOpFormatBuilder(op: AddOp): AddOpFormat.Builder =
     AddOpFormat.newBuilder.setEntry(commonSerializer.payloadFormatBuilder(op.entry.asInstanceOf[AnyRef]))
@@ -196,8 +196,8 @@ class CRDTSerializer(system: ExtendedActorSystem) extends Serializer {
   private def updateOp(opFormat: UpdateOpFormat): UpdateOp =
     UpdateOp(commonSerializer.payload(opFormat.getDelta))
 
-  private def setOp(opFormat: SetOpFormat): SetOp =
-    SetOp(commonSerializer.payload(opFormat.getValue))
+  private def assignOp(opFormat: AssignOpFormat): AssignOp =
+    AssignOp(commonSerializer.payload(opFormat.getValue))
 
   private def addOp(opFormat: AddOpFormat): AddOp =
     AddOp(commonSerializer.payload(opFormat.getEntry))

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/CRDTService.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/CRDTService.scala
@@ -63,7 +63,7 @@ trait CRDTServiceOps[A, B] {
   /**
    * Update phase 2 ("downstream").
    */
-  def update(crdt: A, operation: Any, event: DurableEvent): A
+  def effect(crdt: A, operation: Any, event: DurableEvent): A
 }
 
 object CRDTService {
@@ -215,7 +215,7 @@ trait CRDTService[A, B] {
 
     override def onEvent = {
       case evt @ ValueUpdated(operation) =>
-        crdt = ops.update(crdt, operation, lastHandledEvent)
+        crdt = ops.effect(crdt, operation, lastHandledEvent)
         context.parent ! OnChange(crdt, operation)
     }
 

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/Counter.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/Counter.scala
@@ -53,7 +53,7 @@ object Counter {
     override def precondition: Boolean =
       false
 
-    override def update(crdt: Counter[A], operation: Any, event: DurableEvent): Counter[A] = operation match {
+    override def effect(crdt: Counter[A], operation: Any, event: DurableEvent): Counter[A] = operation match {
       case UpdateOp(delta) => crdt.update(delta.asInstanceOf[A])
     }
   }

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/MVRegister.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/MVRegister.scala
@@ -28,9 +28,8 @@ import scala.concurrent.Future
  * assigning a [[Versioned]] value with a vector timestamp that is greater than those of the currently assigned
  * [[Versioned]] values.
  *
- * @param versioned Registered values. Initially empty.
- * @tparam A MV-Register value type.
- *
+ * @param versioned Assigned values. Initially empty.
+ * @tparam A Assigned value type.
  * @see [[http://hal.upmc.fr/docs/00/55/55/88/PDF/techreport.pdf A comprehensive study of Convergent and Commutative Replicated Data Types]]
  */
 case class MVRegister[A](versioned: Set[Versioned[A]] = Set.empty[Versioned[A]]) extends CRDTFormat {
@@ -40,17 +39,17 @@ case class MVRegister[A](versioned: Set[Versioned[A]] = Set.empty[Versioned[A]])
   /**
    * Assigns a [[Versioned]] value from `v` and `vectorTimestamp` and returns an updated MV-Register.
    *
-   * @param v assigned value.
-   * @param vectorTimestamp vector timestamp of the assigned value.
-   * @param systemTimestamp system timestamp of the assigned value.
+   * @param v value to assign.
+   * @param vectorTimestamp vector timestamp of the value to assign.
+   * @param systemTimestamp system timestamp of the value to assign.
    * @param emitterId id of the value emitter.
    */
-  def set(v: A, vectorTimestamp: VectorTime, systemTimestamp: Long = 0L, emitterId: String = ""): MVRegister[A] = {
+  def assign(v: A, vectorTimestamp: VectorTime, systemTimestamp: Long = 0L, emitterId: String = ""): MVRegister[A] = {
     val (vvs, updated) = versioned.foldLeft((Set.empty[Versioned[A]], false)) {
-      case ((acc, updated), vv) if vectorTimestamp > vv.vectorTimestamp =>
-        ((acc + vv.copy(v, vectorTimestamp)), true)
-      case ((acc, updated), vv) =>
-        ((acc + vv), updated)
+      case ((acc, upd), vv) if vectorTimestamp > vv.vectorTimestamp =>
+        (acc + vv.copy(v, vectorTimestamp), true)
+      case ((acc, upd), vv) /* vectorTimestamp conc vv.vectorTimestamp */ =>
+        (acc + vv, upd)
     }
     if (!updated) copy(versioned + Versioned(v, vectorTimestamp, systemTimestamp, emitterId)) else copy(vvs)
   }
@@ -70,8 +69,8 @@ object MVRegister {
     override def precondition: Boolean =
       false
 
-    override def update(crdt: MVRegister[A], operation: Any, event: DurableEvent): MVRegister[A] = operation match {
-      case SetOp(value) => crdt.set(value.asInstanceOf[A], event.vectorTimestamp, event.systemTimestamp, event.emitterId)
+    override def effect(crdt: MVRegister[A], operation: Any, event: DurableEvent): MVRegister[A] = operation match {
+      case AssignOp(value) => crdt.assign(value.asInstanceOf[A], event.vectorTimestamp, event.systemTimestamp, event.emitterId)
     }
   }
 }
@@ -89,13 +88,13 @@ class MVRegisterService[A](val serviceId: String, val log: ActorRef)(implicit va
   /**
    * Assigns a `value` to the MV-Register identified by `id` and returns the updated MV-Register value.
    */
-  def set(id: String, value: A): Future[Set[A]] =
-    op(id, SetOp(value))
+  def assign(id: String, value: A): Future[Set[A]] =
+    op(id, AssignOp(value))
 
   start()
 }
 
 /**
- * Persistent set operation used for [[MVRegister]] and [[LWWRegister]].
+ * Persistent assign operation used for [[MVRegister]] and [[LWWRegister]].
  */
-case class SetOp(value: Any) extends CRDTFormat
+case class AssignOp(value: Any) extends CRDTFormat

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/ORCart.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/ORCart.scala
@@ -97,7 +97,7 @@ object ORCart {
         super.prepare(crdt, op)
     }
 
-    override def update(crdt: ORCart[A], operation: Any, event: DurableEvent): ORCart[A] = operation match {
+    override def effect(crdt: ORCart[A], operation: Any, event: DurableEvent): ORCart[A] = operation match {
       case RemoveOp(_, timestamps) =>
         crdt.remove(timestamps)
       case AddOp(ORCartEntry(key, quantity)) =>

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/ORSet.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/ORSet.scala
@@ -79,7 +79,7 @@ object ORSet {
         super.prepare(crdt, op)
     }
 
-    override def update(crdt: ORSet[A], operation: Any, event: DurableEvent): ORSet[A] = operation match {
+    override def effect(crdt: ORSet[A], operation: Any, event: DurableEvent): ORSet[A] = operation match {
       case RemoveOp(_, timestamps) =>
         crdt.remove(timestamps)
       case AddOp(entry) =>

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/japi/LWWRegisterService.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/japi/LWWRegisterService.scala
@@ -46,5 +46,5 @@ class LWWRegisterService[A](val serviceId: String, val log: ActorRef, implicit v
    * Assigns a `value` to the LWW-Register identified by `id` and returns the updated LWW-Register value.
    */
   def set(id: String, value: A): CompletionStage[JOption[A]] =
-    delegate.set(id, value).asJava
+    delegate.assign(id, value).asJava
 }

--- a/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/japi/MVRegisterService.scala
+++ b/eventuate-crdt/src/main/scala/com/rbmhtechnology/eventuate/crdt/japi/MVRegisterService.scala
@@ -47,5 +47,5 @@ class MVRegisterService[A](val serviceId: String, val log: ActorRef, implicit va
    * Assigns a `value` to the MV-Register identified by `id` and returns the updated MV-Register value.
    */
   def set(id: String, value: A): CompletionStage[JSet[A]] =
-    delegate.set(id, value).asJava
+    delegate.assign(id, value).asJava
 }

--- a/eventuate-crdt/src/test/scala/com/rbmhtechnology/eventuate/crdt/CRDTSpec.scala
+++ b/eventuate-crdt/src/test/scala/com/rbmhtechnology/eventuate/crdt/CRDTSpec.scala
@@ -35,32 +35,32 @@ class CRDTSpec extends WordSpec with Matchers with BeforeAndAfterEach {
     }
     "store a single value" in {
       mvReg
-        .set(1, vectorTime(1, 0))
+        .assign(1, vectorTime(1, 0))
         .value should be(Set(1))
     }
     "store multiple values in case of concurrent writes" in {
       mvReg
-        .set(1, vectorTime(1, 0))
-        .set(2, vectorTime(0, 1))
+        .assign(1, vectorTime(1, 0))
+        .assign(2, vectorTime(0, 1))
         .value should be(Set(1, 2))
     }
     "mask duplicate concurrent writes" in {
       mvReg
-        .set(1, vectorTime(1, 0))
-        .set(1, vectorTime(0, 1))
+        .assign(1, vectorTime(1, 0))
+        .assign(1, vectorTime(0, 1))
         .value should be(Set(1))
     }
     "replace a value if it happened before a new write" in {
       mvReg
-        .set(1, vectorTime(1, 0))
-        .set(2, vectorTime(2, 0))
+        .assign(1, vectorTime(1, 0))
+        .assign(2, vectorTime(2, 0))
         .value should be(Set(2))
     }
     "replace multiple concurrent values if they happened before a new write" in {
       mvReg
-        .set(1, vectorTime(1, 0))
-        .set(2, vectorTime(0, 1))
-        .set(3, vectorTime(1, 1))
+        .assign(1, vectorTime(1, 0))
+        .assign(2, vectorTime(0, 1))
+        .assign(3, vectorTime(1, 1))
         .value should be(Set(3))
     }
   }
@@ -71,33 +71,33 @@ class CRDTSpec extends WordSpec with Matchers with BeforeAndAfterEach {
     }
     "store a single value" in {
       lwwReg
-        .set(1, vectorTime(1, 0), 0, "source-1")
+        .assign(1, vectorTime(1, 0), 0, "source-1")
         .value should be(Some(1))
     }
     "accept a new value if was set after the current value according to the vector clock" in {
       lwwReg
-        .set(1, vectorTime(1, 0), 1, "emitter-1")
-        .set(2, vectorTime(2, 0), 0, "emitter-2")
+        .assign(1, vectorTime(1, 0), 1, "emitter-1")
+        .assign(2, vectorTime(2, 0), 0, "emitter-2")
         .value should be(Some(2))
     }
     "fallback to the wall clock if the values' vector clocks are concurrent" in {
       lwwReg
-        .set(1, vectorTime(1, 0), 0, "emitter-1")
-        .set(2, vectorTime(0, 1), 1, "emitter-2")
+        .assign(1, vectorTime(1, 0), 0, "emitter-1")
+        .assign(2, vectorTime(0, 1), 1, "emitter-2")
         .value should be(Some(2))
       lwwReg
-        .set(1, vectorTime(1, 0), 1, "emitter-1")
-        .set(2, vectorTime(0, 1), 0, "emitter-2")
+        .assign(1, vectorTime(1, 0), 1, "emitter-1")
+        .assign(2, vectorTime(0, 1), 0, "emitter-2")
         .value should be(Some(1))
     }
     "fallback to the greatest emitter if the values' vector clocks and wall clocks are concurrent" in {
       lwwReg
-        .set(1, vectorTime(1, 0), 0, "emitter-1")
-        .set(2, vectorTime(0, 1), 0, "emitter-2")
+        .assign(1, vectorTime(1, 0), 0, "emitter-1")
+        .assign(2, vectorTime(0, 1), 0, "emitter-2")
         .value should be(Some(2))
       lwwReg
-        .set(1, vectorTime(1, 0), 0, "emitter-2")
-        .set(2, vectorTime(0, 1), 0, "emitter-1")
+        .assign(1, vectorTime(1, 0), 0, "emitter-2")
+        .assign(2, vectorTime(0, 1), 0, "emitter-1")
         .value should be(Some(1))
     }
   }


### PR DESCRIPTION
- rename update to effect (matches academic literature)
- rename set operation to assign (for Register CRDTs)
- needed for upcoming Eventuate CRDT article