### PR TITLE
VertxSingleConfirmationSenderSpec failed

### DIFF
--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcherSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/LogEventDispatcherSpec.scala
@@ -62,7 +62,9 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
   import ProcessingResult._
   import VertxHandlerConverters._
   import system.dispatcher
-  import utilities._
+
+  var endpoint1: String = _
+  var endpoint2: String = _
 
   var logA: ActorRef = _
   var logB: ActorRef = _
@@ -73,6 +75,9 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
   override def beforeEach(): Unit = {
     super.beforeEach()
     registerEventBusCodec(classOf[ProcessingResult])
+
+    endpoint1 = endpointAddress("1")
+    endpoint2 = endpointAddress("2")
 
     logA = system.actorOf(logProps(logId("logA")))
     logB = system.actorOf(logProps(logId("logB")))
@@ -120,7 +125,7 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
         persist(endpoint1, "ev-1")
         persist(endpoint1, "ev-2")
 
-        logAProbe.receiveInAnyOrder(
+        logAProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id1", event = "ev-1"),
           ReadEvent(emitterId = "id1", event = "ev-2"))
       }
@@ -133,7 +138,7 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
         persist(endpoint1, "ev-1")
         persist(endpoint2, "ev-2")
 
-        logAProbe.receiveInAnyOrder(
+        logAProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id1", event = "ev-1"),
           ReadEvent(emitterId = "id1", event = "ev-2"))
       }
@@ -149,11 +154,11 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
         persist(endpoint2, "ev-b1")
         persist(endpoint2, "ev-b2")
 
-        logAProbe.receiveInAnyOrder(
+        logAProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id-a", event = "ev-a1"),
           ReadEvent(emitterId = "id-a", event = "ev-a2"))
 
-        logBProbe.receiveInAnyOrder(
+        logBProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id-b", event = "ev-b1"),
           ReadEvent(emitterId = "id-b", event = "ev-b2"))
       }
@@ -167,7 +172,7 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
         persist(endpoint1, "ev-3")
         persist(endpoint1, "ev-4-filter")
 
-        logAProbe.receiveInAnyOrder(
+        logAProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id-a1", event = "ev-1"),
           ReadEvent(emitterId = "id-a1", event = "ev-3"))
       }
@@ -207,7 +212,7 @@ class LogEventDispatcherSpec extends TestKit(ActorSystem("test", TestConfig.defa
         persist(endpoint1, "ev-fail").failed.await mustBe a[ReplyException]
         persist(endpoint1, "ev-2").await must be(PERSISTED)
 
-        logAProbe.receiveInAnyOrder(
+        logAProbe.expectMsgAllOf(
           ReadEvent(emitterId = "id1", event = "ev-1"),
           ReadEvent(emitterId = "id1", event = "ev-2"))
       }

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxAdapterSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxAdapterSpec.scala
@@ -60,7 +60,7 @@ class VertxAdapterSpec extends TestKit(ActorSystem("test", VertxAdapterSpec.Conf
       val adapterConfig = VertxAdapterConfig()
         .addProducer(EventProducer.fromLog(log)
           .publishTo {
-            case _ => endpoint1
+            case _ => endpoint1.address
           }
           .as("adapter1"))
         .registerDefaultCodecFor(classOf[Event])
@@ -76,20 +76,20 @@ class VertxAdapterSpec extends TestKit(ActorSystem("test", VertxAdapterSpec.Conf
       storage.expectRead(replySequenceNr = 0)
       storage.expectWrite(sequenceNr = 1)
 
-      endpoint1Probe.expectVertxMsg(body = Event("1"))
+      endpoint1.probe.expectVertxMsg(body = Event("1"))
 
       logWriter.write(Seq(Event("2"))).await
 
       storage.expectWrite(sequenceNr = 2)
 
-      endpoint1Probe.expectVertxMsg(body = Event("2"))
+      endpoint1.probe.expectVertxMsg(body = Event("2"))
 
       logWriter.write(Seq(Event("3"), Event("4"))).await
 
       storage.expectWriteAnyOf(sequenceNrs = Seq(3, 4))
 
-      endpoint1Probe.expectVertxMsg(body = Event("3"))
-      endpoint1Probe.expectVertxMsg(body = Event("4"))
+      endpoint1.probe.expectVertxMsg(body = Event("3"))
+      endpoint1.probe.expectVertxMsg(body = Event("4"))
     }
   }
 }

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxBatchConfirmationSenderSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxBatchConfirmationSenderSpec.scala
@@ -47,179 +47,179 @@ class VertxBatchConfirmationSenderSpec extends TestKit(ActorSystem("test", TestC
     "reading events from an event log" must {
       "deliver events to a single consumer" in {
         writeEvents("e", 5)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1))
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address))
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1")
-        endpoint1Probe.expectVertxMsg(body = "e-2")
-        endpoint1Probe.expectVertxMsg(body = "e-3")
-        endpoint1Probe.expectVertxMsg(body = "e-4")
-        endpoint1Probe.expectVertxMsg(body = "e-5")
+        endpoint1.probe.expectVertxMsg(body = "e-1")
+        endpoint1.probe.expectVertxMsg(body = "e-2")
+        endpoint1.probe.expectVertxMsg(body = "e-3")
+        endpoint1.probe.expectVertxMsg(body = "e-4")
+        endpoint1.probe.expectVertxMsg(body = "e-5")
       }
       "deliver events based on the replication progress" in {
         writeEvents("e", 5)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1))
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address))
 
         storage.expectRead(replySequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3")
-        endpoint1Probe.expectVertxMsg(body = "e-4")
-        endpoint1Probe.expectVertxMsg(body = "e-5")
+        endpoint1.probe.expectVertxMsg(body = "e-3")
+        endpoint1.probe.expectVertxMsg(body = "e-4")
+        endpoint1.probe.expectVertxMsg(body = "e-5")
       }
       "persist event confirmations" in {
         writeEvents("e", 3)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1))
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address))
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
 
         storage.expectWrite(sequenceNr = 3)
       }
       "persist event confirmations in batches" in {
         writeEvents("e", 4)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1), batchSize = 2)
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address), batchSize = 2)
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
 
         storage.expectWrite(sequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-4").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-4").confirm()
 
         storage.expectWrite(sequenceNr = 4)
       }
       "persist event confirmations in batches of smaller size if no further events present" in {
         writeEvents("e", 3)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1), batchSize = 2)
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address), batchSize = 2)
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
 
         storage.expectWrite(sequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
 
         storage.expectWrite(sequenceNr = 3)
       }
       "redeliver whole batch if events are unconfirmed" in {
         writeEvents("e", 5)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1))
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address))
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1")
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-4").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-5").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1")
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-4").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-5").confirm()
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1")
-        endpoint1Probe.expectVertxMsg(body = "e-2")
-        endpoint1Probe.expectVertxMsg(body = "e-3")
-        endpoint1Probe.expectVertxMsg(body = "e-4")
-        endpoint1Probe.expectVertxMsg(body = "e-5")
+        endpoint1.probe.expectVertxMsg(body = "e-1")
+        endpoint1.probe.expectVertxMsg(body = "e-2")
+        endpoint1.probe.expectVertxMsg(body = "e-3")
+        endpoint1.probe.expectVertxMsg(body = "e-4")
+        endpoint1.probe.expectVertxMsg(body = "e-5")
       }
       "redeliver unconfirmed event batches while replaying events" in {
         writeEvents("e", 4)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1), batchSize = 2)
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address), batchSize = 2)
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
 
         storage.expectWrite(sequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-4")
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-4")
 
         storage.expectRead(replySequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-4").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-4").confirm()
 
         storage.expectWrite(sequenceNr = 4)
       }
       "redeliver unconfirmed event batches while processing new events" in {
         writeEvents("e", 2)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1), batchSize = 2)
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address), batchSize = 2)
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
 
         storage.expectWrite(sequenceNr = 2)
 
         writeEvents("e", 1, start = 3)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3")
+        endpoint1.probe.expectVertxMsg(body = "e-3")
 
         storage.expectRead(replySequenceNr = 2)
 
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
 
         storage.expectWrite(sequenceNr = 3)
       }
       "deliver selected events only" in {
         writeEvents("e", 10)
         vertxBatchConfirmationSender(EndpointRouter.route {
-          case ev: String if isOddEvent(ev, "e") => endpoint1
+          case ev: String if isOddEvent(ev, "e") => endpoint1.address
         })
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-5").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-7").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-9").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-5").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-7").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-9").confirm()
 
         storage.expectWrite(sequenceNr = 10)
       }
       "route events to different endpoints" in {
         writeEvents("e", 10)
         vertxBatchConfirmationSender(EndpointRouter.route {
-          case ev: String if isEvenEvent(ev, "e") => endpoint1
-          case ev: String if isOddEvent(ev, "e") => endpoint2
+          case ev: String if isEvenEvent(ev, "e") => endpoint1.address
+          case ev: String if isOddEvent(ev, "e") => endpoint2.address
         })
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-4").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-6").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-8").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-10").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-4").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-6").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-8").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-10").confirm()
 
-        endpoint2Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint2Probe.expectVertxMsg(body = "e-3").confirm()
-        endpoint2Probe.expectVertxMsg(body = "e-5").confirm()
-        endpoint2Probe.expectVertxMsg(body = "e-7").confirm()
-        endpoint2Probe.expectVertxMsg(body = "e-9").confirm()
+        endpoint2.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint2.probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint2.probe.expectVertxMsg(body = "e-5").confirm()
+        endpoint2.probe.expectVertxMsg(body = "e-7").confirm()
+        endpoint2.probe.expectVertxMsg(body = "e-9").confirm()
 
         storage.expectWrite(sequenceNr = 10)
       }
       "deliver no events if the routing does not match" in {
         writeEvents("e", 10)
         vertxBatchConfirmationSender(EndpointRouter.route {
-          case "i-will-never-match" => endpoint1
+          case "i-will-never-match" => endpoint1.address
         })
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectNoMsg(1.second)
+        endpoint1.probe.expectNoMsg(1.second)
 
         storage.expectWrite(sequenceNr = 10)
       }
@@ -227,20 +227,20 @@ class VertxBatchConfirmationSenderSpec extends TestKit(ActorSystem("test", TestC
     "encountering a write failure" must {
       "restart and start at the last position" in {
         writeEvents("e", 3)
-        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1))
+        vertxBatchConfirmationSender(EndpointRouter.routeAllTo(endpoint1.address))
 
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-2").confirm()
-        endpoint1Probe.expectVertxMsg(body = "e-3").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-1").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-2").confirm()
+        endpoint1.probe.expectVertxMsg(body = "e-3").confirm()
 
         storage.expectWriteAndFail(sequenceNr = 3, failure = new RuntimeException("storage write failure."))
         storage.expectRead(replySequenceNr = 0)
 
-        endpoint1Probe.expectVertxMsg(body = "e-1")
-        endpoint1Probe.expectVertxMsg(body = "e-2")
-        endpoint1Probe.expectVertxMsg(body = "e-3")
+        endpoint1.probe.expectVertxMsg(body = "e-1")
+        endpoint1.probe.expectVertxMsg(body = "e-2")
+        endpoint1.probe.expectVertxMsg(body = "e-3")
       }
     }
   }

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxEnvironment.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxEnvironment.scala
@@ -16,16 +16,14 @@
 
 package com.rbmhtechnology.eventuate.adapter.vertx
 
+import java.util.UUID
+
 import akka.testkit.TestKit
 import io.vertx.core.Vertx
 import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait VertxEnvironment extends BeforeAndAfterEach {
   this: TestKit with Suite =>
-
-  val endpoint1 = "vertx-endpoint1"
-  val endpoint2 = "vertx-endpoint2"
-  val endpoint3 = "vertx-endpoint3"
 
   var vertx: Vertx = _
 
@@ -37,4 +35,7 @@ trait VertxEnvironment extends BeforeAndAfterEach {
   def registerEventBusCodec(clazz: Class[_]): Unit = {
     vertx.eventBus().registerDefaultCodec(clazz.asInstanceOf[Class[AnyRef]], AkkaSerializationMessageCodec(clazz))
   }
+
+  def endpointAddress(id: String): String =
+    s"vertx-endpoint-$id-${UUID.randomUUID().toString}"
 }

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxNoConfirmationPublisherSpec.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/VertxNoConfirmationPublisherSpec.scala
@@ -44,112 +44,112 @@ class VertxNoConfirmationPublisherSpec extends TestKit(ActorSystem("test", TestC
   "A VertxNoConfirmationPublisher" must {
     "publish events from the beginning of the event log" in {
       val writtenEvents = writeEvents("ev", 50)
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 0)
       storage.expectWrite(sequenceNr = 50)
       storage.expectNoMsg(1.second)
 
-      endpoint1Probe.receiveNVertxMsg[String](50).map(_.body) must be(writtenEvents.map(_.payload))
+      endpoint1.probe.receiveNVertxMsg[String](50).map(_.body) must be(writtenEvents.map(_.payload))
     }
     "publish events from a stored sequence number" in {
       val writtenEvents = writeEvents("ev", 50)
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 10)
       storage.expectWrite(sequenceNr = 50)
       storage.expectNoMsg(1.second)
 
-      endpoint1Probe.receiveNVertxMsg[String](40).map(_.body) must be(writtenEvents.drop(10).map(_.payload))
+      endpoint1.probe.receiveNVertxMsg[String](40).map(_.body) must be(writtenEvents.drop(10).map(_.payload))
     }
     "publish events in batches" in {
       val writtenEvents = writeEvents("ev", 100)
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 0)
       storage.expectWrite(sequenceNr = 50)
       storage.expectWrite(sequenceNr = 100)
       storage.expectNoMsg(1.second)
 
-      endpoint1Probe.receiveNVertxMsg[String](100).map(_.body) must be(writtenEvents.map(_.payload))
+      endpoint1.probe.receiveNVertxMsg[String](100).map(_.body) must be(writtenEvents.map(_.payload))
     }
     "publish events to multiple consumers" in {
-      val otherConsumer = eventBusProbe(endpoint1)
+      val otherConsumer = EventBusEndpoint(endpoint1.address)
 
       writeEvents("e", 3)
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 0)
 
-      endpoint1Probe.expectVertxMsg(body = "e-1")
-      endpoint1Probe.expectVertxMsg(body = "e-2")
-      endpoint1Probe.expectVertxMsg(body = "e-3")
+      endpoint1.probe.expectVertxMsg(body = "e-1")
+      endpoint1.probe.expectVertxMsg(body = "e-2")
+      endpoint1.probe.expectVertxMsg(body = "e-3")
 
-      otherConsumer.expectVertxMsg(body = "e-1")
-      otherConsumer.expectVertxMsg(body = "e-2")
-      otherConsumer.expectVertxMsg(body = "e-3")
+      otherConsumer.probe.expectVertxMsg(body = "e-1")
+      otherConsumer.probe.expectVertxMsg(body = "e-2")
+      otherConsumer.probe.expectVertxMsg(body = "e-3")
 
       storage.expectWrite(sequenceNr = 3)
     }
     "publish selected events only" in {
       writeEvents("e", 10)
       vertxPublisher(EndpointRouter.route {
-        case ev: String if isOddEvent(ev, "e") => endpoint1
+        case ev: String if isOddEvent(ev, "e") => endpoint1.address
       })
 
       storage.expectRead(replySequenceNr = 0)
 
-      endpoint1Probe.expectVertxMsg(body = "e-1")
-      endpoint1Probe.expectVertxMsg(body = "e-3")
-      endpoint1Probe.expectVertxMsg(body = "e-5")
-      endpoint1Probe.expectVertxMsg(body = "e-7")
-      endpoint1Probe.expectVertxMsg(body = "e-9")
+      endpoint1.probe.expectVertxMsg(body = "e-1")
+      endpoint1.probe.expectVertxMsg(body = "e-3")
+      endpoint1.probe.expectVertxMsg(body = "e-5")
+      endpoint1.probe.expectVertxMsg(body = "e-7")
+      endpoint1.probe.expectVertxMsg(body = "e-9")
 
       storage.expectWrite(sequenceNr = 10)
     }
     "route events to different endpoints" in {
       writeEvents("e", 10)
       vertxPublisher(EndpointRouter.route {
-        case ev: String if isEvenEvent(ev, "e") => endpoint1
-        case ev: String if isOddEvent(ev, "e") => endpoint2
+        case ev: String if isEvenEvent(ev, "e") => endpoint1.address
+        case ev: String if isOddEvent(ev, "e") => endpoint2.address
       })
 
       storage.expectRead(replySequenceNr = 0)
 
-      endpoint1Probe.expectVertxMsg(body = "e-2")
-      endpoint1Probe.expectVertxMsg(body = "e-4")
-      endpoint1Probe.expectVertxMsg(body = "e-6")
-      endpoint1Probe.expectVertxMsg(body = "e-8")
-      endpoint1Probe.expectVertxMsg(body = "e-10")
+      endpoint1.probe.expectVertxMsg(body = "e-2")
+      endpoint1.probe.expectVertxMsg(body = "e-4")
+      endpoint1.probe.expectVertxMsg(body = "e-6")
+      endpoint1.probe.expectVertxMsg(body = "e-8")
+      endpoint1.probe.expectVertxMsg(body = "e-10")
 
-      endpoint2Probe.expectVertxMsg(body = "e-1")
-      endpoint2Probe.expectVertxMsg(body = "e-3")
-      endpoint2Probe.expectVertxMsg(body = "e-5")
-      endpoint2Probe.expectVertxMsg(body = "e-7")
-      endpoint2Probe.expectVertxMsg(body = "e-9")
+      endpoint2.probe.expectVertxMsg(body = "e-1")
+      endpoint2.probe.expectVertxMsg(body = "e-3")
+      endpoint2.probe.expectVertxMsg(body = "e-5")
+      endpoint2.probe.expectVertxMsg(body = "e-7")
+      endpoint2.probe.expectVertxMsg(body = "e-9")
 
       storage.expectWrite(sequenceNr = 10)
     }
     "deliver no events if the routing does not match" in {
       writeEvents("e", 10)
       vertxPublisher(EndpointRouter.route {
-        case "i-will-never-match" => endpoint1
+        case "i-will-never-match" => endpoint1.address
       })
 
       storage.expectRead(replySequenceNr = 0)
 
-      endpoint1Probe.expectNoMsg(1.second)
+      endpoint1.probe.expectNoMsg(1.second)
 
       storage.expectWrite(sequenceNr = 10)
     }
     "send event metadata in event bus message headers" in {
       val event = writeEvents("e", 1).head
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 0)
       storage.expectWrite(sequenceNr = 1)
 
-      val msg = endpoint1Probe.expectVertxMsg(body = "e-1")
+      val msg = endpoint1.probe.expectVertxMsg(body = "e-1")
 
       msg.headers.get(EventMetadata.Headers.LocalLogId) mustBe event.localLogId
       msg.headers.get(EventMetadata.Headers.LocalSequenceNr).toLong mustBe event.localSequenceNr
@@ -157,12 +157,12 @@ class VertxNoConfirmationPublisherSpec extends TestKit(ActorSystem("test", TestC
     }
     "send event metadata in event bus message headers readable from EventMetadata" in {
       val event = writeEvents("e", 1).head
-      vertxPublisher(EndpointRouter.routeAllTo(endpoint1))
+      vertxPublisher(EndpointRouter.routeAllTo(endpoint1.address))
 
       storage.expectRead(replySequenceNr = 0)
       storage.expectWrite(sequenceNr = 1)
 
-      val msg = endpoint1Probe.expectVertxMsg(body = "e-1")
+      val msg = endpoint1.probe.expectVertxMsg(body = "e-1")
       val metadata = EventMetadata.fromHeaders(msg.headers)
 
       metadata.map(_.localLogId) mustBe Some(event.localLogId)

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/utilities/EventBusMessage.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/utilities/EventBusMessage.scala
@@ -20,7 +20,7 @@ import com.rbmhtechnology.eventuate.adapter.vertx.Confirmation
 import io.vertx.core.MultiMap
 import io.vertx.core.eventbus.Message
 
-case class VertxEventBusMessage[T](body: T, message: Message[T]) {
+case class EventBusMessage[T](body: T, message: Message[T], address: String) {
   def confirm(): Unit = {
     message.reply(Confirmation)
   }

--- a/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/utilities/package.scala
+++ b/eventuate-adapter-vertx/src/it/scala/com/rbmhtechnology/eventuate/adapter/vertx/utilities/package.scala
@@ -24,22 +24,15 @@ import scala.util.Failure
 
 package object utilities {
 
-  implicit class TestProbeExtension(probe: TestProbe) {
-    def receiveInAnyOrder[T](objs: T*): Unit = {
-      val received = probe.receiveN(objs.size)
-      objs.foreach(o => assert(received.contains(o), s"$received did not contain $o"))
-    }
-  }
-
   implicit class VertxTestProbeExtension(probe: TestProbe) {
-    def expectVertxMsg[T](body: T, max: Duration = Duration.Undefined)(implicit t: ClassTag[T]): VertxEventBusMessage[T] = {
-      probe.expectMsgPF[VertxEventBusMessage[T]](max, hint = s"VertxEventBusMessage($body, _)") {
-        case m: VertxEventBusMessage[T] if m.body == body => m
+    def expectVertxMsg[T](body: T, max: Duration = Duration.Undefined)(implicit t: ClassTag[T]): EventBusMessage[T] = {
+      probe.expectMsgPF[EventBusMessage[T]](max, hint = s"EventBusMessage($body, _, _)") {
+        case m: EventBusMessage[T] if m.body == body => m
       }
     }
 
-    def receiveNVertxMsg[T](n: Int): Seq[VertxEventBusMessage[T]] =
-      probe.receiveN(n).asInstanceOf[Seq[VertxEventBusMessage[T]]]
+    def receiveNVertxMsg[T](n: Int): Seq[EventBusMessage[T]] =
+      probe.receiveN(n).asInstanceOf[Seq[EventBusMessage[T]]]
 
     def expectFailure[T](max: Duration = Duration.Undefined)(implicit t: ClassTag[T]): T = {
       probe.expectMsgPF[T](max, hint = s"Failure($t)") {


### PR DESCRIPTION
- create dynamic Vert.x endpoint addresses for each test case to prevent receipt of messages from previous tests
- remove unnecessary assertion method

- closes #332