### PR TITLE
support retry on recovery

### DIFF
--- a/eventuate-adapter-stream/src/main/resources/reference.conf
+++ b/eventuate-adapter-stream/src/main/resources/reference.conf
@@ -1,3 +1,0 @@
-eventuate.adapter.stream {
-  read-retry-delay = 10s
-}

--- a/eventuate-adapter-stream/src/test/scala/com/rbmhtechnology/eventuate/adapter/stream/DurableEventSourceActorSpec.scala
+++ b/eventuate-adapter-stream/src/test/scala/com/rbmhtechnology/eventuate/adapter/stream/DurableEventSourceActorSpec.scala
@@ -84,7 +84,7 @@ object DurableEventSourceActorSpec {
   val ProcessId = "process"
   val LogId = "log"
 
-  val config = ConfigFactory.parseString("eventuate.adapter.stream.read-retry-delay = 500ms")
+  val config = ConfigFactory.parseString("eventuate.log.replay-retry-delay = 500ms")
 
   val e1 = durableEvent("a", 1)
   val e2 = durableEvent("b", 2)
@@ -145,7 +145,7 @@ class DurableEventSourceActorSpec extends TestKit(ActorSystem("test", DurableEve
   }
 
   def replayFailure(cause: Throwable): Unit = {
-    val msg = ReplayFailure(cause, 1)
+    val msg = ReplayFailure(cause, 1L, 1)
     log.sender() ! msg
     prb.expectMsg(msg)
   }

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpec.scala
@@ -443,7 +443,7 @@ trait EventLogSpec extends TestKitBase with EventLogSpecSupport {
     }
     "reply with a failure message if replay fails" in {
       log.tell(Replay(ErrorSequenceNr, None, 0), replyToProbe.ref)
-      replyToProbe.expectMsg(ReplayFailure(IntegrationTestException, 0))
+      replyToProbe.expectMsg(ReplayFailure(IntegrationTestException, ErrorSequenceNr, 0))
     }
     "replication-read local events" in {
       generateEmittedEvents()

--- a/eventuate-core/src/main/resources/reference.conf
+++ b/eventuate-core/src/main/resources/reference.conf
@@ -44,6 +44,12 @@ eventuate {
     # resumed automatically after the replayed event batch has been handled
     # (= replay backpressure).
     replay-batch-size = 4096
+
+    # Maximum number of replay attempts before finally stopping the actor itself
+    replay-retry-max = 10
+
+    # Delay between consecutive replay attempts
+    replay-retry-delay = 10s
   }
 
   log.circuit-breaker {

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedView.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedView.scala
@@ -33,6 +33,12 @@ private class EventsourcedViewSettings(config: Config) {
   val replayBatchSize =
     config.getInt("eventuate.log.replay-batch-size")
 
+  val replayRetryMax =
+    config.getInt("eventuate.log.replay-retry-max")
+
+  val replayRetryDelay =
+    config.getDuration("eventuate.log.replay-retry-delay", TimeUnit.MILLISECONDS).millis
+
   val readTimeout =
     config.getDuration("eventuate.log.read-timeout", TimeUnit.MILLISECONDS).millis
 
@@ -101,6 +107,7 @@ trait EventsourcedView extends Actor with Stash {
   private var _lastReceivedSequenceNr = 0L
 
   private val settings = new EventsourcedViewSettings(context.system.settings.config)
+
   private var saveRequests: Map[SnapshotMetadata, Handler[SnapshotMetadata]] = Map.empty
 
   private lazy val _commandContext: BehaviorContext = new DefaultBehaviorContext(onCommand)
@@ -382,14 +389,14 @@ trait EventsourcedView extends Actor with Stash {
     val iid = instanceId
 
     eventLog ? Replay(fromSequenceNr, replayBatchSize, sub, aggregateId, instanceId) recover {
-      case t => ReplayFailure(t, iid)
+      case t => ReplayFailure(t, fromSequenceNr, iid)
     } pipeTo self
   }
 
   /**
    * Internal API.
    */
-  private[eventuate] def initiating: Receive = {
+  private[eventuate] def initiating(replayAttempts: Int): Receive = {
     case LoadSnapshotSuccess(Some(snapshot), iid) => if (iid == instanceId) {
       val behavior = _snapshotContext.current
       if (behavior.isDefinedAt(snapshot.payload)) {
@@ -415,13 +422,26 @@ trait EventsourcedView extends Actor with Stash {
     }
     case ReplaySuccess(events, progress, iid) => if (iid == instanceId) {
       events.foreach(receiveEvent)
+      // reset retry attempts
+      context.become(initiating(settings.replayRetryMax))
       replay(progress + 1L)
     }
-    case ReplayFailure(cause, iid) => if (iid == instanceId) {
-      logger.error(cause, s"replay failed, stopping self")
-      Try(onRecovery(Failure(cause)))
-      context.stop(self)
+    case ReplayFailure(cause, progress, iid) => if (iid == instanceId) {
+      if (replayAttempts < 1) {
+        logger.error(cause, "replay failed (maximum number of {} replay attempts reached), stopping self", settings.replayRetryMax)
+        Try(onRecovery(Failure(cause)))
+        context.stop(self)
+      } else {
+        // retry replay request while decreasing the remaining attempts
+        val attemptsRemaining = replayAttempts - 1
+        logger.warning("replay failed [{}] ({} replay attempts remaining), scheduling retry in {}ms",
+          cause.getMessage, attemptsRemaining, settings.replayRetryDelay.toMillis)
+        context.become(initiating(attemptsRemaining))
+        context.system.scheduler.scheduleOnce(settings.replayRetryDelay, self, ReplayRetry(progress))
+      }
     }
+    case ReplayRetry(progress) =>
+      replay(progress)
     case Terminated(ref) if ref == eventLog =>
       context.stop(self)
     case other =>
@@ -454,7 +474,7 @@ trait EventsourcedView extends Actor with Stash {
   /**
    * Initialization behavior.
    */
-  final def receive = initiating
+  final def receive = initiating(settings.replayRetryMax)
 
   /**
    * Adds the current command to the user's command stash. Must not be used in the event handler.
@@ -494,3 +514,4 @@ trait EventsourcedView extends Actor with Stash {
     super.postStop()
   }
 }
+

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedWriter.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedWriter.scala
@@ -17,9 +17,15 @@
 package com.rbmhtechnology.eventuate
 
 import akka.actor._
+import com.typesafe.config.Config
 
 import scala.concurrent.Future
 import scala.util._
+
+private class EventsourcedWriterSettings(config: Config) {
+  val replayRetryMax =
+    config.getInt("eventuate.log.replay-retry-max")
+}
 
 object EventsourcedWriter {
   /**
@@ -85,6 +91,8 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
 
   private case class WriteSuccess(result: W, instanceId: Int)
   private case class WriteFailure(cause: Throwable, instanceId: Int)
+
+  private val settings = new EventsourcedWriterSettings(context.system.settings.config)
 
   private var numPending: Int = 0
 
@@ -165,7 +173,7 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
   /**
    * Internal API.
    */
-  override private[eventuate] def initiating: Receive = {
+  override private[eventuate] def initiating(replayAttempts: Int): Receive = {
     case ReadSuccess(r, iid) => if (iid == instanceId) {
       readSuccess(r) match {
         case Some(snr) => replay(snr, subscribe = true)
@@ -184,12 +192,14 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
     case ReplaySuccess(events, progress, iid) => if (iid == instanceId) {
       events.foreach(receiveEvent)
       if (numPending > 0) {
-        context.become(initiatingWrite(progress) orElse initiating)
+        context.become(initiatingWrite(progress) orElse initiating(settings.replayRetryMax))
         write(instanceId)
-      } else replay(progress + 1L)
+      } else {
+        replay(progress + 1L)
+      }
     }
     case other =>
-      super.initiating(other)
+      super.initiating(replayAttempts)(other)
   }
 
   /**
@@ -210,7 +220,7 @@ trait EventsourcedWriter[R, W] extends EventsourcedView {
   private def initiatingWrite(progress: Long): Receive = {
     case WriteSuccess(r, iid) => if (iid == instanceId) {
       writeSuccess(r)
-      context.become(initiating)
+      context.become(initiating(settings.replayRetryMax))
       replay(progress + 1L)
     }
     case WriteFailure(cause, iid) => if (iid == instanceId) {

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcingProtocol.scala
@@ -84,7 +84,12 @@ object EventsourcingProtocol {
   /**
    * Failure reply after a [[Replay]].
    */
-  case class ReplayFailure(cause: Throwable, instanceId: Int)
+  case class ReplayFailure(cause: Throwable, replayProgress: Long, instanceId: Int)
+
+  /**
+   * Internal message to trigger a new [[Replay]] attempt
+   */
+  private[eventuate] case class ReplayRetry(replayProgress: Long)
 
   /**
    * Instructs an event log to delete events with a sequence nr less or equal a given one.

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/EventLog.scala
@@ -387,7 +387,7 @@ abstract class EventLog[A <: EventLogState](id: String) extends Actor with Event
       }
       read(adjustFromSequenceNr(from), clock.sequenceNr, max, emitterAggregateId) onComplete {
         case Success(r) => sdr ! ReplaySuccess(r.events, r.to, iid)
-        case Failure(e) => sdr ! ReplayFailure(e, iid)
+        case Failure(e) => sdr ! ReplayFailure(e, from, iid)
       }
     case Replay(from, max, subscriber, None, iid) =>
       import services.readDispatcher
@@ -397,7 +397,7 @@ abstract class EventLog[A <: EventLogState](id: String) extends Actor with Event
       }
       read(adjustFromSequenceNr(from), clock.sequenceNr, max) onComplete {
         case Success(r) => sdr ! ReplaySuccess(r.events, r.to, iid)
-        case Failure(e) => sdr ! ReplayFailure(e, iid)
+        case Failure(e) => sdr ! ReplayFailure(e, from, iid)
       }
     case r @ ReplicationRead(from, max, scanLimit, filter, targetLogId, _, currentTargetVersionVector) =>
       import services.readDispatcher

--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedViewSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedViewSpec.java
@@ -188,7 +188,7 @@ public class AbstractEventsourcedViewSpec extends BaseSpec {
         logProbe.sender().tell(new LoadSnapshotSuccess(Option.empty(), instanceId), logProbe.ref());
         logProbe.expectMsg(new Replay(1L, MAX_REPLAY_SIZE, Option.apply(actor), Option.empty(), instanceId));
 
-        actor.tell(new ReplayFailure(FAILURE, instanceId), getRef());
+        actor.tell(new ReplayFailure(FAILURE, 1L, instanceId), getRef());
         msgProbe.expectMsg(FAILURE);
     }
 

--- a/eventuate-core/src/test/resources/reference.conf
+++ b/eventuate-core/src/test/resources/reference.conf
@@ -1,2 +1,7 @@
 akka.loglevel = "ERROR"
 akka.test.single-expect-default = 20s
+
+eventuate.log {
+  replay-retry-delay = 5ms
+  replay-retry-max = 0
+}

--- a/src/sphinx/conf/common.conf
+++ b/src/sphinx/conf/common.conf
@@ -42,3 +42,11 @@ akka.remote.netty.tcp.maximum-frame-size = 128000b
 //#replay-batch-size
 eventuate.log.replay-batch-size = 4096
 //#
+
+//#replay-retry-max
+eventuate.log.replay-retry-max = 10
+//#
+
+//#replay-retry-delay
+eventuate.log.replay-retry-delay = 10s
+//#

--- a/src/sphinx/reference/configuration.rst
+++ b/src/sphinx/reference/configuration.rst
@@ -26,9 +26,4 @@ eventuate-log-leveldb
 
 .. literalinclude:: ../../../eventuate-log-leveldb/src/main/resources/reference.conf
 
-eventuate-adapter-stream
-------------------------
-
-.. literalinclude:: ../../../eventuate-adapter-stream/src/main/resources/reference.conf
-
 .. _config: https://github.com/typesafehub/config

--- a/src/sphinx/reference/event-sourcing.rst
+++ b/src/sphinx/reference/event-sourcing.rst
@@ -170,7 +170,15 @@ When an event-sourced actor or view is started or re-started, events are replaye
 .. includecode:: ../code/EventSourcingDoc.scala
    :snippet: recovery-handler
 
-If replay fails the completion handler is called with a ``Failure`` and the actor will be stopped, regardless of the action taken by the handler. The default recovery completion handler does nothing.
+If replay fails the completion handler is called with a ``Failure`` and the actor will be stopped, regardless of the action taken by the handler. The default recovery completion handler does nothing. Internally each replay request towards the event log is retried a couple of times in order to cope with a temporarily unresponsive event log or its underlying storage backend. The maximum number of retries for a replay request can be configured with:
+
+.. includecode:: ../conf/common.conf
+   :snippet: replay-retry-max
+
+Moreover the configuration value ``replay-retry-delay`` is used to determine the delay between consecutive replay attempts:
+
+.. includecode:: ../conf/common.conf
+   :snippet: replay-retry-delay
 
 At the beginning of event replay, the initiating actor is registered at its event log so that newly written events can be routed to that actor. During replay, the actor internally stashes these newly written events and dispatches them to ``onEvent`` after successful replay. In a similar way, the actor also stashes new commands and dispatches them to ``onCommand`` afterwards. This ensures that new commands never see partially recovered state. When the actor is stopped it is automatically de-registered from its event log.
 


### PR DESCRIPTION
Hi,

especially during recovery of huge event logs it is desirable to have some kind of retry-mechanism of the event log's replay. Otherwise a small hiccup on the storage backend that didn't respond in a timely manner will lead to an immediate shutdown of the `EventsourcedView` and therefore discard all of its progress so far.

Cheers,
Gregor