### PR TITLE
Revive build.properties, remove byte order mark

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-﻿sbt.version=0.13.11
+sbt.version=0.13.11


### PR DESCRIPTION
The BOM was introduced with commit 2e97ed2. Since then the sbt version in `build.properties` was ignored (by the sbt launcher), in consequence the sbt launcher's sbt version was used.

If the sbt launcher was now updated to 0.13.13, the warnings described in #351 popped up.

Resolves #351