### PR TITLE
Limit number of update notifications sent

### DIFF
--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/NotificationChannel.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/log/NotificationChannel.scala
@@ -16,15 +16,32 @@
 
 package com.rbmhtechnology.eventuate.log
 
-import akka.actor.Actor
+import java.util.concurrent.TimeUnit
 
+import akka.actor.Actor
+import akka.actor.ActorRef
 import com.rbmhtechnology.eventuate._
 import com.rbmhtechnology.eventuate.ReplicationProtocol._
+import com.typesafe.config.Config
 
 import scala.collection.immutable.Seq
+import scala.concurrent.duration.DurationLong
+import scala.concurrent.duration.FiniteDuration
+
+class NotificationChannelSettings(config: Config) {
+  val registrationExpirationDuration: FiniteDuration =
+    config.getDuration("eventuate.log.replication.retry-delay", TimeUnit.MILLISECONDS).millis
+}
 
 object NotificationChannel {
   case class Updated(events: Seq[DurableEvent])
+
+  private case class Registration(replicator: ActorRef, currentTargetVersionVector: VectorTime, filter: ReplicationFilter, registrationTime: Long)
+
+  private object Registration {
+    def apply(read: ReplicationRead): Registration =
+      new Registration(read.replicator, read.currentTargetVersionVector, read.filter, System.nanoTime())
+  }
 }
 
 /**
@@ -33,22 +50,26 @@ object NotificationChannel {
 class NotificationChannel(logId: String) extends Actor {
   import NotificationChannel._
 
+  private val settings = new NotificationChannelSettings(context.system.settings.config)
+
   // targetLogId -> subscription
-  private var registry: Map[String, ReplicationRead] = Map.empty
+  private var registry: Map[String, Registration] = Map.empty
 
   // targetLogIds for which a read operation is in progress
   private var reading: Set[String] = Set.empty
 
   def receive = {
     case Updated(events) =>
+      val currentTime = System.nanoTime()
       registry.foreach {
         case (targetLogId, reg) =>
-          if (!reading.contains(targetLogId) && events.exists(_.replicable(reg.currentTargetVersionVector, reg.filter))) {
+          if (!reading.contains(targetLogId)
+            && events.exists(_.replicable(reg.currentTargetVersionVector, reg.filter))
+            && currentTime - reg.registrationTime <= settings.registrationExpirationDuration.toNanos)
             reg.replicator ! ReplicationDue
-          }
       }
     case r: ReplicationRead =>
-      registry += (r.targetLogId -> r)
+      registry += (r.targetLogId -> Registration(r))
       reading += r.targetLogId
     case r: ReplicationReadSuccess =>
       reading -= r.targetLogId


### PR DESCRIPTION
Do not send update notifications forever to avoid spamming the
application log due to akka remoting problems when partner was shutdown.

closes #364