### PR TITLE
toggle aggregate indexing on cassandra event log

### DIFF
--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecCassandra.scala
@@ -20,7 +20,6 @@ import java.io.File
 
 import akka.actor._
 import akka.testkit._
-
 import com.rbmhtechnology.eventuate.log._
 import com.rbmhtechnology.eventuate.log.cassandra._
 import com.rbmhtechnology.eventuate.log.cassandra.CassandraIndex.AggregateEvents
@@ -45,20 +44,20 @@ object SingleLocationSpecCassandra {
     failAfterIndexIncrementWrite: Boolean = false)
 
   object TestEventLog {
-    def props(logId: String, batching: Boolean): Props =
-      props(logId, TestFailureSpec(), None, batching)
+    def props(logId: String, batching: Boolean, aggregateIndexing: Boolean): Props =
+      props(logId, TestFailureSpec(), None, batching, aggregateIndexing)
 
-    def props(logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef, batching: Boolean): Props =
-      props(logId, failureSpec, Some(indexProbe), batching)
+    def props(logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef, batching: Boolean, aggregateIndexing: Boolean): Props =
+      props(logId, failureSpec, Some(indexProbe), batching, aggregateIndexing)
 
-    def props(logId: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef], batching: Boolean): Props = {
-      val logProps = Props(new TestEventLog(logId, failureSpec, indexProbe)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
+    def props(logId: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef], batching: Boolean, aggregateIndexing: Boolean): Props = {
+      val logProps = Props(new TestEventLog(logId, failureSpec, indexProbe, aggregateIndexing)).withDispatcher("eventuate.log.dispatchers.write-dispatcher")
       Props(new CircuitBreaker(logProps, batching))
     }
   }
 
-  class TestEventLog(id: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef])
-    extends CassandraEventLog(id) with SingleLocationSpec.TestEventLog[CassandraEventLogState] {
+  class TestEventLog(id: String, failureSpec: TestFailureSpec, indexProbe: Option[ActorRef], aggregateIndexing: Boolean)
+    extends CassandraEventLog(id, aggregateIndexing) with SingleLocationSpec.TestEventLog[CassandraEventLogState] {
 
     override def currentSystemTime: Long = 0L
 
@@ -128,7 +127,7 @@ trait SingleLocationSpecCassandra extends SingleLocationSpec with LocationCleanu
     logProps(logId, TestFailureSpec(), system.deadLetters)
 
   def logProps(logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef): Props =
-    TestEventLog.props(logId, failureSpec, indexProbe, batching)
+    TestEventLog.props(logId, failureSpec, indexProbe, batching, aggregateIndexing = true)
 
   def createLog(failureSpec: TestFailureSpec, indexProbe: ActorRef): ActorRef = {
     generateLogId()

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecsCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/LocationSpecsCassandra.scala
@@ -42,7 +42,7 @@ class EventsourcedActorThroughputSpecCassandra extends TestKit(ActorSystem("test
 // --------------------------------------------------------------------------
 
 class EventsourcedActorCausalitySpecCassandra extends EventsourcedActorCausalitySpec with MultiLocationSpecCassandra {
-  override val logFactory: String => Props = id => SingleLocationSpecCassandra.TestEventLog.props(id, batching = true)
+  override val logFactory: String => Props = id => SingleLocationSpecCassandra.TestEventLog.props(id, batching = true, aggregateIndexing = true)
 }
 
 class ReplicationIntegrationSpecCassandra extends ReplicationIntegrationSpec with MultiLocationSpecCassandra {

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/CircuitBreakerIntregrationSpecCassandra.scala
@@ -58,7 +58,7 @@ object CircuitBreakerIntregrationSpecCassandra {
     appLatch: CountDownLatch,
     logLatch: CountDownLatch)
 
-  class TestEventLog(id: String, failureSpec: TestFailureSpec) extends CassandraEventLog(id) {
+  class TestEventLog(id: String, failureSpec: TestFailureSpec) extends CassandraEventLog(id, aggregateIndexing = true) {
     override private[eventuate] def createEventLogStore(cassandra: Cassandra, logId: String) =
       new TestEventLogStore(cassandra, logId, failureSpec)
   }

--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
@@ -39,6 +39,13 @@ object EventLogSpecCassandra {
     """.stripMargin).withFallback(EventLogSpec.config)
 }
 
+class EventLogSpecCassandraNoIndexing extends TestKit(ActorSystem("test", EventLogSpecCassandra.config)) with EventLogSpec with SingleLocationSpecCassandra {
+  import SingleLocationSpecCassandra._
+
+  override def logProps(logId: String, failureSpec: TestFailureSpec, indexProbe: ActorRef): Props =
+    TestEventLog.props(logId, failureSpec, indexProbe, batching, aggregateIndexing = false)
+}
+
 class EventLogSpecCassandra extends TestKit(ActorSystem("test", EventLogSpecCassandra.config)) with EventLogSpec with SingleLocationSpecCassandra {
   import EventLogSpec._
   import CassandraIndex._


### PR DESCRIPTION
`CassandraEventLog.props` now supports an additional argument called
`aggregateIndexing` to toggle indexing operations on the event log. If
you don't use aggregate IDs disabling the indexing may significantly
reduce the pressure on the Cassandra database (especially with high
write loads).