### PR TITLE
Add documentation for TLS setup

### DIFF
--- a/src/sphinx/code/create-keystore.sh
+++ b/src/sphinx/code/create-keystore.sh
@@ -1,0 +1,93 @@
+#!/bin/bash -eu
+
+export PW=<...>
+
+CaAlias=rootca
+CaKeystore=rootca.jks
+CaExport=root.crt
+
+CertAlias=serverandclient
+CertKeystore=keystore.jks
+CertSigningRequest=serverandclient.csr
+CertSigned=serverandclient.crt
+
+logStep() {
+    echo
+    echo '=========' "$@"
+    echo
+}
+
+rm -f "$CaKeystore" "$CertKeystore" "$CaExport" "$CertSigningRequest" "$CertSigned"
+
+logStep Create root CA in $CaKeystore
+keytool -genkeypair \
+  -alias "$CaAlias" \
+  -dname "CN=CA" \
+  -keystore "$CaKeystore" \
+  -keypass:env PW \
+  -storepass:env PW \
+  -keyalg RSA \
+  -keysize 4096 \
+  -ext KeyUsage:critical="keyCertSign" \
+  -ext BasicConstraints:critical="ca:true" \
+  -validity 3700
+
+logStep Export root CA to $CaExport for import into truststore
+keytool -export \
+  -alias "$CaAlias" \
+  -file "$CaExport" \
+  -keypass:env PW \
+  -storepass:env PW \
+  -keystore "$CaKeystore" \
+  -rfc
+
+logStep Make $CertKeystore trust CA as signer
+keytool -import \
+  -alias "$CaAlias" \
+  -file "$CaExport" \
+  -keystore "$CertKeystore" \
+  -storepass:env PW << EOF
+yes
+EOF
+
+logStep Create certificate for client and server auth in $CertKeystore
+keytool -genkeypair \
+  -alias "$CertAlias" \
+  -dname "CN=Unknown" \
+  -keystore "$CertKeystore" \
+  -keypass:env PW \
+  -storepass:env PW \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 385
+
+logStep Create a certificate signing request: $CertSigningRequest
+keytool -certreq \
+  -alias "$CertAlias" \
+  -keypass:env PW \
+  -storepass:env PW \
+  -keystore "$CertKeystore" \
+  -file "$CertSigningRequest"
+
+logStep Sign certificate with CA: $CertSigned
+keytool -gencert \
+  -alias "$CaAlias" \
+  -keypass:env PW \
+  -storepass:env PW \
+  -keystore "$CaKeystore" \
+  -infile "$CertSigningRequest" \
+  -outfile "$CertSigned" \
+  -ext KeyUsage:critical="digitalSignature,keyEncipherment" \
+  -rfc
+
+logStep Import signed certificate back into $CertKeystore
+keytool -import \
+  -alias "$CertAlias" \
+  -file "$CertSigned" \
+  -keystore "$CertKeystore" \
+  -storepass:env PW
+
+logStep List $CertKeystore
+keytool -list \
+  -keystore "$CertKeystore" \
+  -storepass:env PW

--- a/src/sphinx/conf/tls.conf
+++ b/src/sphinx/conf/tls.conf
@@ -1,0 +1,20 @@
+akka {
+  remote {
+    enabled-transports = [akka.remote.netty.ssl]
+    netty.ssl.security {
+      key-store = "/path/to/keystore.jks"
+      trust-store = "/path/to/keystore.jks"
+
+      key-store-password = ...
+      key-password = ...
+      trust-store-password = ...
+
+      protocol = "TLSv1.2"
+
+      enabled-algorithms = ["TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
+
+      random-number-generator = "AES256CounterSecureRNG"
+      require-mutual-authentication = on
+    }
+  }
+}

--- a/src/sphinx/reference/configuration.rst
+++ b/src/sphinx/reference/configuration.rst
@@ -1,29 +1,49 @@
+.. _transport-security:
+
+Transport Security
+------------------
+
+In a setup with several locations Eventuate uses `Akka Remoting`_ for communication between locations. Akka Remoting supports using TLS as transport protocol. In combination with mutual authentication (client and server) this allows to prevent that untrusted nodes can connect to a replication network. The configuration snippet listed here acts as an example for how to set this up. For more details see `Configuring SSL/TLS for Akka Remoting`_.
+
+.. literalinclude:: ../conf/tls.conf
+
+This example uses a single file for key- and trust-store. Having a single self-signed certificate in this store suffices to establish mutually authenticated connections via TLS between locations. However a self-signed key makes replacing the certificate in a rolling upgrade tedious. The following script (derived from the scripts of the documentation of `Lightbend's SSL-Config library`_) creates a root certificate that is used to sign the certificate for client and server authentication. The root certificate is kept in the private keystore ``rootca.jks``, which does not have to be deployed with the application. It is imported as ``trustedCertEntry`` into the keystore ``keystore.jks``, which is the one referenced by the akka configuration.
+
+.. literalinclude:: ../code/create-keystore.sh
+
+If the certificate for client and server authentication shall be replaced, corresponding key-stores can be deployed location by location without the need to stop the entire replication network at once.
+
+For debugging TLS connections please read `Debugging SSL/TLS Connections`_ from the java documentation.
+
 .. _configuration:
 
--------------
 Configuration
 -------------
 
 This is the reference configuration of Eventuate. It is processed by Typesafe's config_ library and can be overridden by applications:
 
 eventuate-core
---------------
+~~~~~~~~~~~~~~
 
 .. literalinclude:: ../../../eventuate-core/src/main/resources/reference.conf
 
 eventuate-crdt
---------------
+~~~~~~~~~~~~~~
 
 .. literalinclude:: ../../../eventuate-crdt/src/main/resources/reference.conf
 
 eventuate-log-cassandra
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: ../../../eventuate-log-cassandra/src/main/resources/reference.conf
 
 eventuate-log-leveldb
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: ../../../eventuate-log-leveldb/src/main/resources/reference.conf
 
 .. _config: https://github.com/typesafehub/config
+.. _Akka Remoting: http://doc.akka.io/docs/akka/2.4/scala/remoting.html
+.. _Configuring SSL/TLS for Akka Remoting: http://doc.akka.io/docs/akka/2.4/scala/remoting.html#Configuring_SSL_TLS_for_Akka_Remoting
+.. _Lightbend's SSL-Config library: http://typesafehub.github.io/ssl-config/CertificateGeneration.html#using-keytool
+.. _Debugging SSL/TLS Connections: http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/ReadDebug.html

--- a/src/sphinx/reference/event-log.rst
+++ b/src/sphinx/reference/event-log.rst
@@ -120,6 +120,8 @@ Each location has a ``ReplicationEndpoint`` that manages the local event logs. R
 .. includecode:: ../conf/location-1.conf
    :snippet: remoting-conf
 
+Next to TCP Akka Remoting also support TLS as transport protocol. See :ref:`transport-security` for details on how to set this up.
+
 The network address of the replication endpoint at location ``1`` is:
 
 .. includecode:: ../conf/location-1.conf


### PR DESCRIPTION
Akka remoting support TLS. The documentation describes how akka
remoting needs to be configured for this and how corresponding
keystores can be prepared.

Closes #380