### PR TITLE
Stylesheets

### DIFF
--- a/src/sphinx/_ext/tabbedcode.css
+++ b/src/sphinx/_ext/tabbedcode.css
@@ -1,7 +1,7 @@
 ul.tabbed-code-selector {
     margin-bottom: 0 !important;
     position: relative;
-    bottom: -22px;
+    bottom: -12px;
     list-style-type: none;
     display: inline-flex;
 }
@@ -16,12 +16,19 @@ ul.tabbed-code-selector li {
     float: left;
     border: 1px solid #e1e4e5;
     background-color: #f5f5f5;
+    border-bottom: none;
     color: #646567;
 }
 ul.tabbed-code-selector li:hover {
     background-color: #ebebeb;
 }
 ul.tabbed-code-selector li.selected {
-    background-color: #f8f8f8;
-    border-bottom: 1px solid #f8f8f8;
+    background-color: #fbf97a;
+    border-bottom: none;
+    color: black;
+}
+
+ul.tabbed-code-selector li[class^='highlight'] {
+  border-top-right-radius: 8px;
+  border-top-left-radius: 8px;
 }

--- a/src/sphinx/_themes/rbmh/layout.html
+++ b/src/sphinx/_themes/rbmh/layout.html
@@ -95,15 +95,15 @@
           {# Not strictly valid HTML, but it's the only way to display/scale it properly, without weird scripting or heaps of work #}
           <a href="{{ pathto(master_doc) }}"><img src="{{ pathto('_static/' + logo, 1) }}" class="logo" /></a>
         {% endif %}
-        
+
 		{% include "searchbox.html" %}
-	
+
         {% endblock %}
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
         {% block menu %}
-          {% set toctree = toctree(maxdepth=2, collapse=False, includehidden=True) %}
+          {% set toctree = toctree(maxdepth=5, collapse=False, includehidden=True) %}
           {% if toctree %}
               {{ toctree }}
           {% else %}
@@ -122,7 +122,7 @@
         <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
         <a href="{{ pathto(master_doc) }}"><img src="{{ pathto('_static/RedBullMediaHouse-light.png', 1) }}" class="logo" /></a>
       </nav>
- 
+
       {# PAGE CONTENT #}
       <div class="wy-nav-content">
         <div class="rst-content">
@@ -143,7 +143,7 @@
         </div>
 	  </div>
     {% include "footer.html" %}
-      
+
     </section>
 
   </div>

--- a/src/sphinx/_themes/rbmh/static/css/theme.css
+++ b/src/sphinx/_themes/rbmh/static/css/theme.css
@@ -30,7 +30,7 @@ audio:not([controls]) {
 }
 
 html {
-  font-size: 100%;
+  font-size: 12pt;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
 }
@@ -75,7 +75,7 @@ mark {
 pre, code, .rst-content tt, kbd, samp {
   font-family: monospace, serif;
   _font-family: "courier new", monospace;
-  font-size: 1em;
+  font-size: 90%;
 }
 
 pre {
@@ -3259,6 +3259,10 @@ input[type="radio"][disabled], input[type="checkbox"][disabled] {
   cursor: not-allowed;
 }
 
+table.footnote code .pre {
+  font-size: 10pt;
+}
+
 .wy-checkbox, .wy-radio {
   margin: 6px 0;
   color: #404040;
@@ -3628,7 +3632,7 @@ html {
 body {
   font-family: "open-sans", "Helvetica Neue", Arial, sans-serif;
   font-weight: normal;
-  color: #404040;
+  color: #242424;
   min-height: 100%;
   overflow-x: hidden;
   background: #edf0f2;
@@ -3712,7 +3716,12 @@ p {
   line-height: 24px;
   margin: 0;
   font-size: 16px;
-  margin-bottom: 24px;
+  margin-bottom: 12px;
+  text-align: justify;
+}
+
+p + p {
+  margin-top: 12px;
 }
 
 h1 {
@@ -3751,16 +3760,16 @@ hr {
 code, .rst-content tt {
   white-space: nowrap;
   max-width: 100%;
-  background: #fff;
-  border: solid 1px #e1e4e5;
-  font-size: 75%;
-  padding: 0 5px;
-  font-family: "open-sans", "Helvetica Neue", Arial, sans-serif;
-  color: #E74C3C;
+  background: none;
+  /*border: solid 1px #e1e4e5;*/
+  font-size: 90%;
+  /*padding: 0 5px;*/
+  font-family: "open-sans", "Helvetica Neue", sans-serif;
+  color: black;
   overflow-x: auto;
 }
 code.code-large, .rst-content tt.code-large {
-  font-size: 90%;
+  font-size: 100%;
 }
 
 .wy-plain-list-disc, .rst-content .section ul, .rst-content .toctree-wrapper ul, article ul {
@@ -3771,6 +3780,7 @@ code.code-large, .rst-content tt.code-large {
 .wy-plain-list-disc li, .rst-content .section ul li, .rst-content .toctree-wrapper ul li, article ul li {
   list-style: disc;
   margin-left: 24px;
+  margin-top: 6pt;
 }
 .wy-plain-list-disc li p:last-child, .rst-content .section ul li p:last-child, .rst-content .toctree-wrapper ul li p:last-child, article ul li p:last-child {
   margin-bottom: 0;
@@ -3788,6 +3798,48 @@ code.code-large, .rst-content tt.code-large {
   list-style: decimal;
 }
 
+.toctree-l2 {
+  text-indent: 0.5em;
+  white-space: nowrap;
+}
+.toctree-l3 {
+  text-indent: 1em;
+  white-space: nowrap;
+}
+.toctree-l4 {
+  text-indent: 1.5em;
+  white-space: nowrap;
+}
+.toctree-l5 {
+  text-indent: 2em;
+  white-space: nowrap;
+}
+.toctree-l6 {
+  text-indent: 2.5em;
+  white-space: nowrap;
+}
+
+.document .section h1 {
+  color: black;
+  font-size: 36px;
+}
+.document .section h2 {
+  font-size: 30px;
+  color: #202325;
+}
+.document .section h3 {
+  font-size: 24px;
+  color: #343739;
+}
+.document .section h4 {
+  font-size: 22px;
+  color: #494c4e;
+}
+.document .section h5 {
+  font-size: 18px;
+  color: #56595b;
+}
+
 .wy-plain-list-decimal, .rst-content .section ol, .rst-content ol.arabic, article ol {
   list-style: decimal;
   line-height: 24px;
@@ -3796,6 +3848,7 @@ code.code-large, .rst-content tt.code-large {
 .wy-plain-list-decimal li, .rst-content .section ol li, .rst-content ol.arabic li, article ol li {
   list-style: decimal;
   margin-left: 24px;
+  margin-top: 6pt;
 }
 .wy-plain-list-decimal li p:last-child, .rst-content .section ol li p:last-child, .rst-content ol.arabic li p:last-child, article ol li p:last-child {
   margin-bottom: 0;
@@ -3837,6 +3890,7 @@ code.code-large, .rst-content tt.code-large {
   background: #fff;
   margin: 1px 0 24px 0;
 }
+
 .codeblock div[class^='highlight'], pre.literal-block div[class^='highlight'], .rst-content .literal-block div[class^='highlight'], div[class^='highlight'] div[class^='highlight'] {
   border: none;
   background: none;
@@ -3860,7 +3914,7 @@ div[class^='highlight'] td.code {
 div[class^='highlight'] pre {
   white-space: pre;
   margin: 0;
-  padding: 12px 12px;
+  /*padding: 12px 12px;*/
   font-family: "open-sans", "Helvetica Neue", Arial, sans-serif;
   font-size: 12px;
   line-height: 1.5;
@@ -4619,7 +4673,7 @@ h4 {
 }
 
 .wy-menu-vertical a, .wy-menu-vertical li.current a {
-  color: #646567;
+  color: #242424;
 }
 
 .wy-menu-vertical a:hover, .wy-menu-vertical li.current > a:hover, .wy-menu-vertical li.current a:hover {
@@ -4642,9 +4696,9 @@ h4 {
   background-color: #f2940a;
 }
 
-.rst-content .warning {
+/*.rst-content .warning {
   background-color: rgba(242, 148, 10, 0.1);
-}
+}*/
 
 .btn-neutral {
   background-color: #f8f8f8;
@@ -4659,7 +4713,8 @@ h4 {
 }
 
 code, .rst-content tt, .rst-content tt {
-  color: #db0a40;
+  color: black;
+  background: none;
   font-family: "Lucida Console", Monaco, monospace;
 }
 
@@ -4767,10 +4822,11 @@ footer p {
   background: #f8f8f8 !important;
   padding: 7px 7px 7px 10px !important;
   border: 1px solid #ddd !important;
-  -moz-box-shadow: 3px 3px rgba(0, 0, 0, 0.1) !important;
+  border-radius: 4px;
+  /*-moz-box-shadow: 3px 3px rgba(0, 0, 0, 0.1) !important;
   -webkit-box-shadow: 3px 3px rgba(0, 0, 0, 0.1) !important;
-  box-shadow: 3px 3px rgba(0, 0, 0, 0.1) !important;
-  margin: 20px 0 20px 0 !important;
+  box-shadow: 3px 3px rgba(0, 0, 0, 0.1) !important;*/
+  margin: 10px 0 10px 0 !important;
 }
 
 div[class^='highlight'] pre {
@@ -4783,7 +4839,7 @@ div[class^='highlight'] pre {
 }
 
 body {
-  color: #646567;
+  color: #242424;
 }
 
 blockquote {
@@ -5109,12 +5165,12 @@ td input:focus {
 }
 .rst-content .footnote-reference, .rst-content .citation-reference {
   vertical-align: super;
-  font-size: 90%;
+  font-size: 8pt;
 }
 .rst-content table.docutils.citation, .rst-content table.docutils.footnote {
   background: none;
   border: none;
-  color: #999;
+ /* color: #999;*/
 }
 .rst-content table.docutils.citation td, .rst-content table.docutils.citation tr, .rst-content table.docutils.footnote td, .rst-content table.docutils.footnote tr {
   border: none;


### PR DESCRIPTION
Most changes won't be noticeable for most people. However, people who are visually impaired, who use a different browser css setup will find these changes to their liking.

* The tightly cropped white border around `<code></code>` is gone. It added no benefit, and made code hard to read
* The side menu now shows `h2`-`h5` entries, instead of just `h2` entries. They are now indented appropriately and do not wrap, so they are shown one per line. Any x-overflow is clipped.
* `h2`-`h5` titles in the document now have slightly different sizes, so the document hierarchy is easier to follow
* Because the width of `<pre></pre>` blocks is so narrow, and the font used was so large, not many characters could be shown. The font is now slightly smaller (12 points, which is a standard size).
* Some spacings were adjusted; this should not be noticeable unless a careful A/B comparison is done.
* Paragraph text is now justified; the document looks more professional this way.
* Only hyperlinks are now shown in red. Previously, code in paragraphs was also shown in red, which made it difficult to know what was a link. Code in paragraphs is now shown in black.
* The text was previously shown in light grey against a white background. This made the document difficult to read for a visually impaired person. Text is now shown in a darker grey.
* Some backgrounds are now transparent, instead of white, because many visually impaired people use a different stylesheet that does not have a white background. Transparent backgrounds mean that the desired colors work better.