### PR TITLE
Use EventId in PersistOnEventRequests

### DIFF
--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/DurableEventSerializerSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/DurableEventSerializerSpec.scala
@@ -106,7 +106,8 @@ object DurableEventSerializerSpec {
     localLogId = "p3",
     localSequenceNr = 17L,
     deliveryId = Some("x"),
-    persistOnEventSequenceNr = Some(12L))
+    persistOnEventSequenceNr = Some(12L),
+    persistOnEventId = Some(EventId("p4", 0L)))
 }
 
 class DurableEventSerializerSpec extends WordSpec with Matchers with Inside with BeforeAndAfterAll {

--- a/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializerSpec.scala
+++ b/eventuate-core/src/it/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializerSpec.scala
@@ -46,8 +46,8 @@ object SnapshotSerializerSpec {
     DeliveryAttempt("4", payload, destination))
 
   def persistOnEventRequests(payload: Any) = Vector(
-    PersistOnEventRequest(7L, Vector(PersistOnEventInvocation(payload, Set("a"))), 17),
-    PersistOnEventRequest(8L, Vector(PersistOnEventInvocation(payload, Set("b"))), 17))
+    PersistOnEventRequest(7L, None, Vector(PersistOnEventInvocation(payload, Set("a"))), 17),
+    PersistOnEventRequest(8L, Some(EventId("p-a", 3L)), Vector(PersistOnEventInvocation(payload, Set("b"))), 17))
 
   def snapshot(payload: Any, destination: ActorPath) =
     Snapshot(payload, "x", last(payload), vectorTime(17, 18), event.localSequenceNr,

--- a/eventuate-core/src/main/protobuf/DurableEventFormats.proto
+++ b/eventuate-core/src/main/protobuf/DurableEventFormats.proto
@@ -31,4 +31,10 @@ message DurableEventFormat {
   optional int64 localSequenceNr = 9;
   optional int64 persistOnEventSequenceNr = 10;
   optional string deliveryId = 11;
+  optional EventIdFormat persistOnEventId = 12;
+}
+
+message EventIdFormat {
+  optional string processId = 1;
+  optional int64 sequenceNr = 2;
 }

--- a/eventuate-core/src/main/protobuf/SnapshotFormats.proto
+++ b/eventuate-core/src/main/protobuf/SnapshotFormats.proto
@@ -37,9 +37,10 @@ message DeliveryAttemptFormat {
 }
 
 message PersistOnEventRequestFormat {
-  optional int64 persistOnEventSequenceNr = 1;
+  optional int64 sequenceNr = 1;
   repeated PersistOnEventInvocationFormat invocation = 2;
   optional int32 instanceId = 3;
+  optional EventIdFormat eventId = 4;
 }
 
 message PersistOnEventInvocationFormat {

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedActor.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedActor.scala
@@ -145,12 +145,12 @@ trait EventsourcedActor extends EventsourcedView with EventsourcedVersion {
         messageStash.unstash()
       }
     }
-    case PersistOnEventRequest(persistOnEventSequenceNr: Long, invocations, iid) => if (iid == instanceId) {
+    case PersistOnEventRequest(persistOnEventSequenceNr, persistOnEventId, invocations, iid) => if (iid == instanceId) {
       writeOrDelay {
         writeHandlers = Vector.fill(invocations.length)(PersistOnEvent.DefaultHandler)
         writeRequests = invocations.map {
           case PersistOnEventInvocation(event, customDestinationAggregateIds) =>
-            durableEvent(event, customDestinationAggregateIds, None, Some(persistOnEventSequenceNr))
+            durableEvent(event, customDestinationAggregateIds, None, Some(persistOnEventSequenceNr), persistOnEventId)
         }
       }
     }

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedVersion.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/EventsourcedVersion.scala
@@ -39,7 +39,7 @@ trait EventsourcedVersion extends EventsourcedView {
    * Internal API.
    */
   private[eventuate] def durableEvent(payload: Any, customDestinationAggregateIds: Set[String],
-    deliveryId: Option[String] = None, persistOnEventSequenceNr: Option[Long] = None): DurableEvent =
+    deliveryId: Option[String] = None, persistOnEventSequenceNr: Option[Long] = None, persistOnEventId: Option[EventId] = None): DurableEvent =
     DurableEvent(
       payload = payload,
       emitterId = id,
@@ -47,7 +47,8 @@ trait EventsourcedVersion extends EventsourcedView {
       customDestinationAggregateIds = customDestinationAggregateIds,
       vectorTimestamp = currentVersion,
       deliveryId = deliveryId,
-      persistOnEventSequenceNr = persistOnEventSequenceNr)
+      persistOnEventSequenceNr = persistOnEventSequenceNr,
+      persistOnEventId = persistOnEventId)
 
   /**
    * Internal API.

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/DelegatingDurableEventSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/DelegatingDurableEventSerializer.scala
@@ -102,6 +102,9 @@ abstract class DurableEventSerializer(
     durableEvent.persistOnEventSequenceNr.foreach { persistOnEventSequenceNr =>
       builder.setPersistOnEventSequenceNr(persistOnEventSequenceNr)
     }
+    durableEvent.persistOnEventId.foreach { persistOnEventId =>
+      builder.setPersistOnEventId(eventIdFormatBuilder(persistOnEventId))
+    }
 
     durableEvent.emitterAggregateId.foreach { id =>
       builder.setEmitterAggregateId(id)
@@ -111,6 +114,13 @@ abstract class DurableEventSerializer(
       builder.addCustomDestinationAggregateIds(dest)
     }
 
+    builder
+  }
+
+  def eventIdFormatBuilder(eventId: EventId) = {
+    val builder = EventIdFormat.newBuilder()
+    builder.setProcessId(eventId.processId)
+    builder.setSequenceNr(eventId.sequenceNr)
     builder
   }
 
@@ -128,6 +138,7 @@ abstract class DurableEventSerializer(
 
     val deliveryId = if (durableEventFormat.hasDeliveryId) Some(durableEventFormat.getDeliveryId) else None
     val persistOnEventSequenceNr = if (durableEventFormat.hasPersistOnEventSequenceNr) Some(durableEventFormat.getPersistOnEventSequenceNr) else None
+    val persistOnEventId = if (durableEventFormat.hasPersistOnEventId) Some(eventId(durableEventFormat.getPersistOnEventId)) else None
 
     DurableEvent(
       payload = payloadSerializer.payload(durableEventFormat.getPayload),
@@ -140,6 +151,10 @@ abstract class DurableEventSerializer(
       localLogId = durableEventFormat.getLocalLogId,
       localSequenceNr = durableEventFormat.getLocalSequenceNr,
       deliveryId = deliveryId,
-      persistOnEventSequenceNr = persistOnEventSequenceNr)
+      persistOnEventSequenceNr = persistOnEventSequenceNr,
+      persistOnEventId = persistOnEventId)
   }
+
+  def eventId(eventId: EventIdFormat) =
+    EventId(eventId.getProcessId, eventId.getSequenceNr)
 }

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializer.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/serializer/SnapshotSerializer.scala
@@ -98,7 +98,10 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
 
   private def persistOnEventRequestFormatBuilder(persistOnEventRequest: PersistOnEventRequest): PersistOnEventRequestFormat.Builder = {
     val builder = PersistOnEventRequestFormat.newBuilder
-    builder.setPersistOnEventSequenceNr(persistOnEventRequest.persistOnEventSequenceNr)
+    builder.setSequenceNr(persistOnEventRequest.persistOnEventSequenceNr)
+    persistOnEventRequest.persistOnEventId.foreach { eventId =>
+      builder.setEventId(eventSerializer.eventIdFormatBuilder(eventId))
+    }
     builder.setInstanceId(persistOnEventRequest.instanceId)
 
     persistOnEventRequest.invocations.foreach { invocation =>
@@ -191,8 +194,11 @@ class SnapshotSerializer(system: ExtendedActorSystem) extends Serializer {
       invocationsBuilder += persistOnEventInvocation(pif)
     }
 
+    val persistOnEventReference = if (persistOnEventRequestFormat.hasEventId) Some(eventSerializer.eventId(persistOnEventRequestFormat.getEventId)) else None
+
     PersistOnEventRequest(
-      persistOnEventRequestFormat.getPersistOnEventSequenceNr,
+      persistOnEventRequestFormat.getSequenceNr,
+      persistOnEventReference,
       invocationsBuilder.result(),
       persistOnEventRequestFormat.getInstanceId)
   }

--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/BaseSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/BaseSpec.java
@@ -105,7 +105,7 @@ public abstract class BaseSpec extends JUnitSuite {
     @SuppressWarnings("unchecked")
     protected DurableEvent createEvent(final Object payload, final long sequenceNr, final String emitterId, final String logId, final VectorTime timestamp) {
         return new DurableEvent(payload, emitterId, Option.empty(), Set$.MODULE$.<String>empty(), 0L,
-                timestamp, logId, logId, sequenceNr, Option.empty(), Option.empty());
+                timestamp, logId, logId, sequenceNr, Option.empty(), Option.empty(), Option.empty());
     }
 
     protected VectorTime timestamp(final long a, final long b) {

--- a/eventuate-log-leveldb/src/it/scala/com/rbmhtechnology/eventuate/PersistOnEventWithRecoverySpecLeveldb.scala
+++ b/eventuate-log-leveldb/src/it/scala/com/rbmhtechnology/eventuate/PersistOnEventWithRecoverySpecLeveldb.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 - 2016 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.eventuate
+
+import java.util.UUID
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.testkit.TestProbe
+import com.rbmhtechnology.eventuate.ReplicationIntegrationSpec.replicationConnection
+import com.rbmhtechnology.eventuate.utilities._
+import org.apache.commons.io.FileUtils
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+import scala.concurrent.duration.DurationInt
+
+object PersistOnEventWithRecoverySpecLeveldb {
+  class OnBEmitRandomActor(val eventLog: ActorRef, probe: TestProbe) extends EventsourcedActor with PersistOnEvent {
+
+    override def id = getClass.getName
+
+    override def onCommand = Actor.emptyBehavior
+
+    override def onEvent = {
+      case "A"          =>
+      case "B"          => persistOnEvent(UUID.randomUUID().toString)
+      case uuid: String => probe.ref ! uuid
+    }
+  }
+
+  def persistOnEventProbe(locationA1: Location, log: ActorRef) = {
+    val probe = locationA1.probe
+    locationA1.system.actorOf(Props(new OnBEmitRandomActor(log, probe)))
+    probe
+  }
+
+  val noMsgTimeout = 100.millis
+}
+
+class PersistOnEventWithRecoverySpecLeveldb extends WordSpec with Matchers with MultiLocationSpecLeveldb {
+  import RecoverySpecLeveldb._
+  import PersistOnEventWithRecoverySpecLeveldb._
+
+  override val logFactory: String => Props =
+    id => SingleLocationSpecLeveldb.TestEventLog.props(id, batching = true)
+
+  "An EventsourcedActor with PersistOnEvent" must {
+    "not re-attempt persistence on successful write after reordering of events through disaster recovery" in {
+      val locationB = location("B", customConfig = RecoverySpecLeveldb.config)
+      def newLocationA = location("A", customConfig = RecoverySpecLeveldb.config)
+      val locationA1 = newLocationA
+
+      val endpointB = locationB.endpoint(Set("L1"), Set(replicationConnection(locationA1.port)))
+      def newEndpointA(l: Location, activate: Boolean) = l.endpoint(Set("L1"), Set(replicationConnection(locationB.port)), activate = activate)
+      val endpointA1 = newEndpointA(locationA1, activate = true)
+
+      val targetA = endpointA1.target("L1")
+      val logDirA = logDirectory(targetA)
+      val targetB = endpointB.target("L1")
+      val a1Probe = persistOnEventProbe(locationA1, targetA.log)
+
+      write(targetA, List("A"))
+      write(targetB, List("B"))
+      val event = a1Probe.expectMsgClass(classOf[String])
+      assertConvergence(Set("A", "B", event), endpointA1, endpointB)
+
+      locationA1.terminate().await
+      FileUtils.deleteDirectory(logDirA)
+
+      val locationA2 = newLocationA
+      val endpointA2 = newEndpointA(locationA2, activate = false)
+      endpointA2.recover().await
+
+      val a2Probe = persistOnEventProbe(locationA2, endpointA2.logs("L1"))
+      a2Probe.expectMsg(event)
+      a2Probe.expectNoMsg(noMsgTimeout)
+      assertConvergence(Set("A", "B", event), endpointA2, endpointB)
+    }
+  }
+}


### PR DESCRIPTION
Instead of using the in case of disaster recovery potentially
unstable sequence number as id for persist on event requests use a
stable EventId that is composed of the sequence number of the emitter
of the event and the corresponding process id.

Closes #385