### PR TITLE
Upgrade to akka 2.5.2

### DIFF
--- a/eventuate-core/src/main/java/com/rbmhtechnology/eventuate/ProcessBuilder.java
+++ b/eventuate-core/src/main/java/com/rbmhtechnology/eventuate/ProcessBuilder.java
@@ -17,66 +17,115 @@
 package com.rbmhtechnology.eventuate;
 
 import akka.japi.pf.FI;
-import akka.japi.pf.Match;
 import akka.japi.pf.PFBuilder;
 
 /**
- * Java API for building a PartialFunction that matches arbitrary [[Object]]s to {@link Iterable}s.
+ * Java API for building a {@link AbstractEventsourcedProcessor.Process} behavior that matches arbitrary [[Object]]s to {@link Iterable}s.
  *
- * Can be used to define processing behaviour in {@link AbstractEventsourcedProcessor#setOnProcessEvent}
- * or {@link AbstractEventsourcedProcessor#onProcessEvent}.
+ * Used to define processing behaviour in {@link AbstractEventsourcedProcessor#createOnProcessEvent}.
  */
 public final class ProcessBuilder {
-    private ProcessBuilder() {
+
+    private final PFBuilder<Object, Iterable<Object>> underlying;
+
+    private ProcessBuilder(PFBuilder<Object, Iterable<Object>> underlying) {
+        this.underlying = underlying;
     }
 
     /**
-     * Returns a new {@link PFBuilder} of {@link java.lang.Iterable} with a case statement added.
+     * Returns a new {@link ProcessBuilder} instance.
+     *
+     * @return a {@link ProcessBuilder}
+     */
+    public static ProcessBuilder create() {
+        return new ProcessBuilder(new PFBuilder<>());
+    }
+
+    /**
+     * Add a new case statement to this builder.
      *
      * @param type the type to match the argument against
-     * @param apply the function to apply for the given argument - must return {@link java.lang.Iterable}
+     * @param apply the function to apply for the given argument - must return {@link Iterable}
      * @param <P> the type of the argument
-     * @return a builder with the case statement added
+     * @return the {@link ProcessBuilder} with the case statement added
      */
-    public static <P> PFBuilder<Object, Iterable<Object>> match(final Class<? extends P> type, final IterableApply<? extends P> apply) {
-        return Match.match(type, apply);
+    public <P> ProcessBuilder match(final Class<P> type, IterableApply<P> apply) {
+        underlying.match(type, apply);
+        return this;
     }
 
     /**
-     * Returns a new {@link PFBuilder} of {@link java.lang.Iterable} with a case statement added.
+     * Add a new case statement to this builder.
      *
      * @param type the type to match the argument against
      * @param predicate the predicate to match the argument against
-     * @param apply the function to apply for the given argument - must return {@link java.lang.Iterable}
+     * @param apply the function to apply for the given argument - must return {@link Iterable}
      * @param <P> the type of the argument
-     * @return a builder with the case statement added
+     * @return the {@link ProcessBuilder} with the case statement added
      */
-    public static <P> PFBuilder<Object, Iterable<Object>> match(final Class<? extends P> type,
-                                                                final FI.TypedPredicate<? extends P> predicate,
-                                                                final IterableApply<? extends P> apply) {
-        return Match.match(type, predicate, apply);
+    public <P> ProcessBuilder match(final Class<P> type, final FI.TypedPredicate<P> predicate, final IterableApply<P> apply) {
+        underlying.match(type, predicate, apply);
+        return this;
     }
 
     /**
-     * Returns a new {@link PFBuilder} of {@link java.lang.Iterable} with a case statement added.
+     * Add a new case statement to this builder without compile time type check of the parameters.
+     * Should normally not be used, but when matching on class with generic type.
+     *
+     * @param type the type to match the argument against
+     * @param apply the function to apply for the given argument - must return {@link Iterable}
+     * @return the {@link ProcessBuilder} with the case statement added
+     */
+    public ProcessBuilder matchUnchecked(final Class<?> type, IterableApply<?> apply) {
+        underlying.matchUnchecked(type, apply);
+        return this;
+    }
+
+    /**
+     * Add a new case statement to this builder without compile time type check of the parameters.
+     * Should normally not be used, but when matching on class with generic type.
+     *
+     * @param type the type to match the argument against
+     * @param predicate a predicate that will be evaluated on the argument if the type matches
+     * @param apply the function to apply for the given argument - must return {@link Iterable}
+     * @return the {@link ProcessBuilder} with the case statement added
+     */
+    public ProcessBuilder matchUnchecked(final Class<?> type, final FI.TypedPredicate<?> predicate, final IterableApply<?> apply) {
+        underlying.matchUnchecked(type, predicate, apply);
+        return this;
+    }
+
+    /**
+     * Add a new case statement to this builder.
      *
      * @param object the object to match the argument against
-     * @param apply the function to apply for the given argument - must return an {@link java.lang.Iterable}
+     * @param apply the function to apply for the given argument - must return an {@link Iterable}
      * @param <P> the type of the argument
-     * @return a builder with the case statement added
+     * @return the {@link ProcessBuilder} with the case statement added
      */
-    public static <P> PFBuilder<Object, Iterable<Object>> matchEquals(final P object, final IterableApply<P> apply) {
-        return Match.matchEquals(object, apply);
+    public <P> ProcessBuilder matchEquals(final P object, final IterableApply<P> apply) {
+        underlying.matchEquals(object, apply);
+        return this;
     }
 
     /**
-     * Returns a new {@link PFBuilder} of {@link java.lang.Iterable} with a default case statement added.
+     * Add a new case statement to this builder, that matches any argument.
      *
-     * @param apply the function to apply for the given argument - must return an {@link java.lang.Iterable}
-     * @return a builder with the case statement added
+     * @param apply the function to apply for the given argument - must return an {@link Iterable}
+     * @return the {@link ProcessBuilder} with the case statement added
      */
-    public static PFBuilder<Object, Iterable<Object>> matchAny(final IterableApply<Object> apply) {
-        return Match.matchAny(apply);
+    public ProcessBuilder matchAny(final IterableApply<Object> apply) {
+        underlying.matchAny(apply);
+        return this;
+    }
+
+    /**
+     * Builds the resulting processing behavior as an instance of {@link AbstractEventsourcedProcessor.Process}.
+     *
+     * @return the configured {@link AbstractEventsourcedProcessor.Process}
+     */
+    public AbstractEventsourcedProcessor.Process build() {
+        return new AbstractEventsourcedProcessor.Process(underlying.build());
     }
 
     public interface IterableApply<T> extends FI.Apply<T, Iterable<Object>> {

--- a/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/AbstractEventsourcedStatefulProcessor.scala
+++ b/eventuate-core/src/main/scala/com/rbmhtechnology/eventuate/AbstractEventsourcedStatefulProcessor.scala
@@ -24,6 +24,6 @@ import akka.actor.ActorRef
  * @see [[AbstractEventsourcedView]] for a detailed usage of the Java API
  * @see [[StatefulProcessor]]
  */
-class AbstractEventsourcedStatefulProcessor(id: String, eventLog: ActorRef, val targetEventLog: ActorRef) extends AbstractEventsourcedView(id, eventLog)
+class AbstractEventsourcedStatefulProcessor(val id: String, val eventLog: ActorRef, val targetEventLog: ActorRef) extends AbstractEventsourcedComponent
   with StatefulProcessor with EventSourcedProcessorAdapter with EventsourcedProcessorWriteSuccessHandlerAdapter {
 }

--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedProcessorSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedProcessorSpec.java
@@ -45,10 +45,13 @@ public class AbstractEventsourcedProcessorSpec extends BaseSpec {
         public TestEventsourcedProcessor(final String id, final ActorRef srcProbe, final ActorRef targetProbe, final ActorRef appProbe) {
             super(id, srcProbe, targetProbe);
             this.appProbe = appProbe;
+        }
 
-            setOnProcessEvent(ProcessBuilder
-                    .match(String.class, s -> Arrays.asList(s + "-1", s + "-2"))
-                    .build());
+        @Override
+        public Process createOnProcessEvent() {
+          return processBuilder()
+            .match(String.class, s -> Arrays.asList(s + "-1", s + "-2"))
+            .build();
         }
 
         @Override

--- a/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedWriterSpec.java
+++ b/eventuate-core/src/test/java/com/rbmhtechnology/eventuate/AbstractEventsourcedWriterSpec.java
@@ -16,6 +16,7 @@
 
 package com.rbmhtechnology.eventuate;
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.actor.Status;
@@ -48,8 +49,13 @@ public class AbstractEventsourcedWriterSpec extends BaseSpec {
             super(id, logProbe);
             this.appProbe = appProbe;
             this.rwProbe = rwProbe;
+        }
 
-            setOnEvent(ReceiveBuilder.match(String.class, ev -> {}).build());
+        @Override
+        public AbstractActor.Receive createOnEvent() {
+            return receiveBuilder()
+                .match(String.class, ev -> {})
+                .build();
         }
 
         @Override
@@ -69,25 +75,25 @@ public class AbstractEventsourcedWriterSpec extends BaseSpec {
 
         @Override
         public Optional<Long> onReadSuccess(final String result) {
-            appProbe.tell(result, self());
+            appProbe.tell(result, getSelf());
             return super.onReadSuccess(result);
         }
 
         @Override
         public void onWriteSuccess(final String result) {
-            appProbe.tell(result, self());
+            appProbe.tell(result, getSelf());
             super.onWriteSuccess(result);
         }
 
         @Override
         public void onReadFailure(final Throwable cause) {
-            appProbe.tell(cause, self());
+            appProbe.tell(cause, getSelf());
             super.onReadFailure(cause);
         }
 
         @Override
         public void onWriteFailure(final Throwable cause) {
-            appProbe.tell(cause, self());
+            appProbe.tell(cause, getSelf());
             super.onWriteFailure(cause);
         }
 

--- a/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/ordermgnt/OrderExample.java
+++ b/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/ordermgnt/OrderExample.java
@@ -57,8 +57,11 @@ public class OrderExample extends AbstractActor {
         this.view = view;
 
         this.reader = new BufferedReader(new InputStreamReader(System.in));
+    }
 
-        receive(ReceiveBuilder
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
                 .match(GetStateSuccess.class, r -> {
                     r.state.values().stream().forEach(OrderActor::printOrder);
                     prompt();
@@ -90,7 +93,7 @@ public class OrderExample extends AbstractActor {
                     prompt();
                 })
                 .match(CommandSuccess.class, r -> prompt())
-                .match(String.class, this::process).build());
+                .match(String.class, this::process).build();
     }
 
     private void prompt() throws IOException {

--- a/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/ordermgnt/OrderView.java
+++ b/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/ordermgnt/OrderView.java
@@ -16,8 +16,8 @@
 
 package com.rbmhtechnology.example.japi.ordermgnt;
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
-import akka.japi.pf.ReceiveBuilder;
 import com.rbmhtechnology.eventuate.AbstractEventsourcedView;
 import com.rbmhtechnology.example.japi.ordermgnt.OrderActor.OrderEvent;
 import javaslang.collection.HashMap;
@@ -29,19 +29,25 @@ public class OrderView extends AbstractEventsourcedView {
     public OrderView(String replicaId, ActorRef eventLog) {
         super(String.format("j-ov-%s", replicaId), eventLog);
         this.updateCounts = HashMap.empty();
+    }
 
-        setOnCommand(ReceiveBuilder
-                .match(GetUpdateCount.class, this::handleGetUpdateCount)
-                .build());
-
-        setOnEvent(ReceiveBuilder
-                .match(OrderEvent.class, this::handleOrderEvent)
-                .build());
+    @Override
+    public AbstractActor.Receive createOnCommand() {
+        return receiveBuilder()
+            .match(GetUpdateCount.class, this::handleGetUpdateCount)
+            .build();
     }
 
     public void handleGetUpdateCount(final GetUpdateCount cmd) {
         final String orderId = cmd.orderId;
-        sender().tell(new GetUpdateCountSuccess(orderId, updateCounts.get(orderId).getOrElse(0)), self());
+        sender().tell(new GetUpdateCountSuccess(orderId, updateCounts.get(orderId).getOrElse(0)), getSelf());
+    }
+
+    @Override
+    public AbstractActor.Receive createOnEvent() {
+        return receiveBuilder()
+            .match(OrderEvent.class, this::handleOrderEvent)
+            .build();
     }
 
     public void handleOrderEvent(final OrderEvent evt) {

--- a/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/querydb/Emitter.java
+++ b/eventuate-examples/src/main/java/com/rbmhtechnology/example/japi/querydb/Emitter.java
@@ -16,8 +16,8 @@
 
 package com.rbmhtechnology.example.japi.querydb;
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
-import akka.japi.pf.ReceiveBuilder;
 import com.rbmhtechnology.eventuate.AbstractEventsourcedActor;
 import com.rbmhtechnology.eventuate.ResultHandler;
 
@@ -29,28 +29,32 @@ public class Emitter extends AbstractEventsourcedActor {
 
     public Emitter(String id, ActorRef eventLog) {
         super(id, eventLog);
+    }
 
-        setOnCommand(ReceiveBuilder
-                .match(CreateCustomer.class,
-                        cmd -> persist(new CustomerCreated(highestCustomerId + 1, cmd.first, cmd.last, cmd.address), ResultHandler.on(
-                                c -> sender().tell(c, self()),
-                                this::handleFailure
-                        )))
-                .match(UpdateAddress.class, cmd -> cmd.cid <= highestCustomerId,
-                        cmd -> persist(new AddressUpdated(cmd.cid, cmd.address), ResultHandler.on(
-                                c -> sender().tell(c, self()),
-                                this::handleFailure
-                        )))
-                .match(UpdateAddress.class,
-                        cmd -> sender().tell(new Exception(String.format("Customer with %s does not exist", cmd.cid)), self())
-                )
-                .build());
+    @Override
+    public AbstractActor.Receive createOnCommand() {
+        return receiveBuilder()
+            .match(CreateCustomer.class,
+                cmd -> persist(new CustomerCreated(highestCustomerId + 1, cmd.first, cmd.last, cmd.address), ResultHandler.on(
+                    c -> getSender().tell(c, getSelf()),
+                    this::handleFailure
+                )))
+            .match(UpdateAddress.class, cmd -> cmd.cid <= highestCustomerId,
+                cmd -> persist(new AddressUpdated(cmd.cid, cmd.address), ResultHandler.on(
+                    c -> getSender().tell(c, getSelf()),
+                    this::handleFailure
+                )))
+            .match(UpdateAddress.class,
+                cmd -> getSender().tell(new Exception(String.format("Customer with %s does not exist", cmd.cid)), getSelf())
+            )
+            .build();
+    }
 
-        setOnEvent(ReceiveBuilder
-                .match(CustomerCreated.class,
-                        evt -> highestCustomerId = evt.cid
-                )
-                .build());
+    @Override
+    public AbstractActor.Receive createOnEvent() {
+        return receiveBuilder()
+            .match(CustomerCreated.class, evt -> highestCustomerId = evt.cid)
+            .build();
     }
 
     private void handleFailure(final Throwable failure) {

--- a/project/ProjectDependencies.scala
+++ b/project/ProjectDependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object ProjectDependencyVersions {
-  val AkkaVersion = "2.4.12"
+  val AkkaVersion = "2.5.2"
   val CassandraVersion = "3.4"
   val Log4jVersion = "2.5"
   val ProtobufVersion = "2.5.0"

--- a/project/ProjectDependencies.scala
+++ b/project/ProjectDependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object ProjectDependencyVersions {
-  val AkkaVersion = "2.5.2"
+  val AkkaVersion = "2.5.6"
   val CassandraVersion = "3.4"
   val Log4jVersion = "2.5"
   val ProtobufVersion = "2.5.0"

--- a/project/ProjectDependencies.scala
+++ b/project/ProjectDependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object ProjectDependencyVersions {
-  val AkkaVersion = "2.5.6"
+  val AkkaVersion = "2.5.7"
   val CassandraVersion = "3.4"
   val Log4jVersion = "2.5"
   val ProtobufVersion = "2.5.0"

--- a/src/sphinx/code/userguide/japi/TrackingExample.java
+++ b/src/sphinx/code/userguide/japi/TrackingExample.java
@@ -20,8 +20,8 @@ import static userguide.japi.DocUtils.append;
 
 //#tracking-conflicting-versions
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
-import akka.japi.pf.ReceiveBuilder;
 import com.rbmhtechnology.eventuate.*;
 
 import java.util.Collection;
@@ -39,21 +39,24 @@ public class TrackingExample {
 
     public ExampleActor(String id, ActorRef eventLog) {
       super(id, eventLog);
-
-      setOnEvent(ReceiveBuilder
-        .match(Appended.class, evt -> {
-          versionedState = versionedState.update(evt.entry, lastVectorTimestamp(), lastSystemTimestamp(), lastEmitterId());
-
-          if (versionedState.conflict()) {
-            final Collection<Versioned<Collection<String>>> all = versionedState.getAll();
-            // TODO: resolve conflicting versions
-          } else {
-            final Collection<String> currentState = versionedState.getAll().get(0).value();
-            // ...
-          }
-        })
-        .build());
     }
+
+    @Override
+    public AbstractActor.Receive createOnEvent() {
+        return receiveBuilder()
+            .match(Appended.class, evt -> {
+                versionedState = versionedState.update(evt.entry, getLastVectorTimestamp(), getLastSystemTimestamp(), getLastEmitterId());
+
+                if (versionedState.conflict()) {
+                    final Collection<Versioned<Collection<String>>> all = versionedState.getAll();
+                    // TODO: resolve conflicting versions
+                } else {
+                    final Collection<String> currentState = versionedState.getAll().get(0).value();
+                    // ...
+                }
+            })
+            .build();
+      }
   }
   //#
 }

--- a/src/sphinx/code/userguide/japi/ViewExample.java
+++ b/src/sphinx/code/userguide/japi/ViewExample.java
@@ -18,8 +18,8 @@ package userguide.japi;
 
 //#event-sourced-view
 
+import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
-import akka.japi.pf.ReceiveBuilder;
 import com.rbmhtechnology.eventuate.AbstractEventsourcedView;
 import com.rbmhtechnology.eventuate.VectorTime;
 //#
@@ -35,16 +35,22 @@ public class ViewExample {
 
     public ExampleView(String id, ActorRef eventLog) {
       super(id, eventLog);
+    }
 
-      setOnCommand(ReceiveBuilder
-        .match(GetAppendCount.class, cmd -> sender().tell(new GetAppendCountReply(appendCount), self()))
-        .match(GetResolveCount.class, cmd -> sender().tell(new GetResolveCountReply(resolveCount), self()))
-        .build());
+    @Override
+    public AbstractActor.Receive createOnCommand() {
+      return receiveBuilder()
+          .match(GetAppendCount.class, cmd -> sender().tell(new GetAppendCountReply(appendCount), getSelf()))
+          .match(GetResolveCount.class, cmd -> sender().tell(new GetResolveCountReply(resolveCount), getSelf()))
+          .build();
+    }
 
-      setOnEvent(ReceiveBuilder
-        .match(Appended.class, evt -> appendCount += 1)
-        .match(Resolved.class, evt -> resolveCount += 1)
-        .build());
+    @Override
+    public AbstractActor.Receive createOnEvent() {
+      return receiveBuilder()
+          .match(Appended.class, evt -> appendCount += 1)
+          .match(Resolved.class, evt -> resolveCount += 1)
+          .build();
     }
   }
 


### PR DESCRIPTION
Akka 2.5.2 introduced the following incompatible changes in the java API
- ReceiveBuilder:
  - explicit create step required
  - builds AbstractActor.Receive instead of Actor.Receive
- Match.match: Changes in type parameters

To adjust to these changes AbstractEventsourcedView gets a new method
receiveBuilder (similar to the one in AbstractActor) and each setOn...
method is overloaded with a variant that accepts an
AbstractActor.Receive (instead of an Actor.Receive)

Closes #390