### PR TITLE
Update scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 after_success:
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then .travis/publish-all.sh $TRAVIS_SCALA_VERSION; fi
 scala:
-  - 2.11.8
-  - 2.12.0
+  - 2.11.12
+  - 2.12.6
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ version in ThisBuild := "0.10-SNAPSHOT"
 
 organization in ThisBuild := "com.rbmhtechnology"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.11.12"
 
 lazy val root = (project in file("."))
   .aggregate(core, crdt, crdtPure, logCassandra, logLeveldb, adapterStream, adapterVertx, examples, exampleStream, exampleVertx)
@@ -92,6 +92,7 @@ lazy val adapterVertx  = (project in file("eventuate-adapter-vertx"))
   .dependsOn(logLeveldb % "it->it")
   .settings(name := "eventuate-adapter-vertx")
   .settings(commonSettings: _*)
+  .settings(scalacOptions += "-target:jvm-1.8")
   .settings(integrationTestSettings: _*)
   .settings(libraryDependencies ++= Seq(AkkaRemote,
       VertxCore % "provided",
@@ -155,5 +156,6 @@ lazy val exampleVertx = (project in file("eventuate-example-vertx"))
   .dependsOn(core, logLeveldb, adapterVertx)
   .settings(name := "eventuate-example-vertx")
   .settings(commonSettings: _*)
+  .settings(scalacOptions += "-target:jvm-1.8")
   .settings(libraryDependencies ++= Seq(AkkaRemote, Leveldb, Javaslang, Log4jApi, Log4jCore, Log4jSlf4j, ExampleVertxCore, ExampleVertxRxJava))
   .enablePlugins(HeaderPlugin, AutomateHeaderPlugin)


### PR DESCRIPTION
Updates scala versions to the latest, 2.11.12 and 2.12.6 as of today.

The update of scala 2.11 to 2.11.12 also required to add "-target:jvm-1.8"
to `scalacOptions` of the vertx adapter module (scalac refused to compile
saying "Static methods in interface require -target:jvm-1.8", and vertx
in fact requires java 8).

### Motivation (for a newer scala 2.12)

After upgrading our project from 2.11 to 2.12, we experienced weird `AbstractMethodError`s several times when running our performance tests:

```
16:53:20.688 [location-akka.actor.default-dispatcher-42] ERROR akka.actor.ActorSystemImpl - Uncaught error from thread [location-eventuate.log.dispatchers.write-
dispatcher-23]: scala.Option.get()Ljava/lang/Object;, shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[location]
java.lang.AbstractMethodError: scala.Option.get()Ljava/lang/Object;
        at scala.Option.foreach(Option.scala:257)
        at com.rbmhtechnology.eventuate.serializer.DurableEventSerializer.durableEventFormatBuilder(DelegatingDurableEventSerializer.scala:105)
        at com.rbmhtechnology.eventuate.serializer.DurableEventSerializer.toBinary(DelegatingDurableEventSerializer.scala:68)
```

Out of curiosity we replaced the original eventuate-core_2.12-0.10-M1.jar with a one built with scala 2.12.6 (from the 0.10-M1 tag of course) - and until now all our performance tests were successful.

Therefore it would be great to have an eventuate release built with the latest scala 2.12.