### PR TITLE
Revert "Skip empty partitions on replay from Cassandra"

### DIFF
--- a/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
+++ b/eventuate-log-cassandra/src/it/scala/com/rbmhtechnology/eventuate/log/EventLogSpecCassandra.scala
@@ -165,14 +165,6 @@ class EventLogSpecCassandra extends TestKit(ActorSystem("test", EventLogSpecCass
 
       indexProbe.expectMsg(UpdateIndexSuccess(EventLogClock(sequenceNr = 2L, versionVector = timestamp(2L)), 1))
     }
-    "replay events in case of large sequence number gaps (with empty partitions)" in {
-      val evt = DurableEvent("a", emitterIdA, processId = logId, vectorTimestamp = VectorTime(logId -> 131072L * 5), localLogId = logId, localSequenceNr = 1)
-      writeReplicatedEvents(List(evt), 0L, remoteLogId)
-      (log ? AdjustEventLogClock).await
-
-      writeEmittedEvents(List(event("b")))
-      expectReplay(None, "a", "b")
-    }
     "replay aggregate events from log" in {
       writeEmittedEvents(List(
         event("a", Some("a1")),


### PR DESCRIPTION
Reverts RBMHTechnology/eventuate#404

Might lead to never ending replay. Could be related to logically deleted events.